### PR TITLE
create and delete bucket in every test

### DIFF
--- a/extensions/transfer/transfer-nifi/src/test/java/com/microsoft/dagx/transfer/nifi/NifiDataFlowControllerTest.java
+++ b/extensions/transfer/transfer-nifi/src/test/java/com/microsoft/dagx/transfer/nifi/NifiDataFlowControllerTest.java
@@ -620,7 +620,7 @@ public class NifiDataFlowControllerTest {
 
     @Test
     @Timeout(20)
-    @DisplayName("Transfer several files from Azure Blob to Azure Blob")
+    @DisplayName("Transfer multiple files from S3 to Azure Blob")
     void transfer_multiple_fromS3_toAzure() throws InterruptedException {
         String id = UUID.randomUUID().toString();
         GenericDataCatalog dataEntry = createS3CatalogEntry();
@@ -660,7 +660,7 @@ public class NifiDataFlowControllerTest {
 
     @Test
     @Timeout(20)
-    @DisplayName("Transfer several files from Azure Blob to Azure Blob")
+    @DisplayName("Transfer all files from Azure Blob to Azure Blob")
     void transfer_all_fromAzureToAzure() throws InterruptedException {
         String id = UUID.randomUUID().toString();
         GenericDataCatalog dataEntry = createAzureCatalogEntry();

--- a/external/nifi/processors/src/test/java/microsoft/dagx/transfer/nifi/processors/AbstractS3Test.java
+++ b/external/nifi/processors/src/test/java/microsoft/dagx/transfer/nifi/processors/AbstractS3Test.java
@@ -48,7 +48,7 @@ public class AbstractS3Test {
         return new BasicAWSCredentials(accessKeyId, secretKey);
     }
 
-    protected void createBucket(AmazonS3 client, String bucketName, String region) {
+    protected void createBucket(String bucketName, String region) {
         if (client.doesBucketExistV2(bucketName)) {
             fail("Bucket " + bucketName + " exists. Choose a different bucket name to continue test");
         }
@@ -86,7 +86,7 @@ public class AbstractS3Test {
 
             DeleteBucketRequest dbr = new DeleteBucketRequest(bucketName);
             client.deleteBucket(dbr);
-        } catch (final AmazonS3Exception e) {
+        } catch (AmazonS3Exception e) {
             System.err.println("Unable to delete bucket " + bucketName + e);
         }
 

--- a/external/nifi/processors/src/test/java/microsoft/dagx/transfer/nifi/processors/AbstractS3Test.java
+++ b/external/nifi/processors/src/test/java/microsoft/dagx/transfer/nifi/processors/AbstractS3Test.java
@@ -34,7 +34,7 @@ public class AbstractS3Test {
     protected AWSCredentials credentials;
 
     @BeforeEach
-    public void oneTimeSetup() {
+    public void setupClient() {
         bucketName = "test-bucket-" + System.currentTimeMillis() + "-" + REGION;
         credentials = getCredentials();
         client = AmazonS3ClientBuilder.standard().withCredentials(new AWSStaticCredentialsProvider(credentials)).withRegion(REGION).build();

--- a/external/nifi/processors/src/test/java/microsoft/dagx/transfer/nifi/processors/FetchS3ObjectTest.java
+++ b/external/nifi/processors/src/test/java/microsoft/dagx/transfer/nifi/processors/FetchS3ObjectTest.java
@@ -11,7 +11,6 @@ import net.jodah.failsafe.RetryPolicy;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,13 +33,7 @@ class FetchS3ObjectTest extends AbstractS3Test {
 
     @BeforeEach
     void setup() {
-        createBucket(bucketName, REGION);
         retryPolicy = new RetryPolicy<>().withBackoff(500, 5000, ChronoUnit.MILLIS).withMaxRetries(5).handle(AssertionError.class);
-    }
-
-    @AfterEach
-    void cleanup() {
-        deleteBucket(bucketName, client);
     }
 
     @Test

--- a/external/nifi/processors/src/test/java/microsoft/dagx/transfer/nifi/processors/FetchS3ObjectTest.java
+++ b/external/nifi/processors/src/test/java/microsoft/dagx/transfer/nifi/processors/FetchS3ObjectTest.java
@@ -34,7 +34,7 @@ class FetchS3ObjectTest extends AbstractS3Test {
 
     @BeforeEach
     void setup() {
-        createBucket(client, bucketName, REGION);
+        createBucket(bucketName, REGION);
         retryPolicy = new RetryPolicy<>().withBackoff(500, 5000, ChronoUnit.MILLIS).withMaxRetries(5).handle(AssertionError.class);
     }
 
@@ -48,7 +48,7 @@ class FetchS3ObjectTest extends AbstractS3Test {
     public void testFetchFile_single() {
         putTestFile("test-file", getFileFromResourceName(SAMPLE_FILE_RESOURCE_NAME), bucketName);
 
-        final TestRunner runner = TestRunners.newTestRunner(new FetchS3Object());
+        TestRunner runner = TestRunners.newTestRunner(new FetchS3Object());
 
         runner.setProperty(Properties.REGION, REGION);
         runner.setProperty(Properties.BUCKET, bucketName);
@@ -57,14 +57,14 @@ class FetchS3ObjectTest extends AbstractS3Test {
         runner.setProperty(Properties.SECRET_ACCESS_KEY, credentials.getAWSSecretKey());
 
 
-        final Map<String, String> attrs = new HashMap<>();
+        Map<String, String> attrs = new HashMap<>();
         runner.enqueue(new byte[0], attrs);
 
         runner.run(1);
 
         Failsafe.with(retryPolicy).run(() -> {
             System.out.println("");
-            final List<MockFlowFile> ffs = runner.getFlowFilesForRelationship(Properties.REL_SUCCESS);
+            List<MockFlowFile> ffs = runner.getFlowFilesForRelationship(Properties.REL_SUCCESS);
             assertThat(ffs).hasSize(1);
 
             MockFlowFile ff = ffs.get(0);
@@ -77,7 +77,7 @@ class FetchS3ObjectTest extends AbstractS3Test {
     @Test
     @DisplayName("Verifies that the 'failure' relationship is traversed when a file is not found in S3")
     void fetchFile_single_whenNotExists() {
-        final TestRunner runner = TestRunners.newTestRunner(new FetchS3Object());
+        TestRunner runner = TestRunners.newTestRunner(new FetchS3Object());
 
         runner.setProperty(Properties.REGION, REGION);
         runner.setProperty(Properties.BUCKET, bucketName);
@@ -86,12 +86,12 @@ class FetchS3ObjectTest extends AbstractS3Test {
         runner.setProperty(Properties.SECRET_ACCESS_KEY, credentials.getAWSSecretKey());
 
 
-        final Map<String, String> attrs = new HashMap<>();
+        Map<String, String> attrs = new HashMap<>();
         runner.enqueue(new byte[0], attrs);
 
         runner.run(1);
         Failsafe.with(retryPolicy).run(() -> {
-            final List<MockFlowFile> ffs = runner.getFlowFilesForRelationship(Properties.REL_FAILURE);
+            List<MockFlowFile> ffs = runner.getFlowFilesForRelationship(Properties.REL_FAILURE);
             assertThat(ffs).hasSize(1);
             MockFlowFile ff = ffs.get(0);
         });
@@ -103,7 +103,7 @@ class FetchS3ObjectTest extends AbstractS3Test {
         String key = "folder/1.txt";
         putTestFile(key, getFileFromResourceName(SAMPLE_FILE_RESOURCE_NAME), bucketName);
 
-        final TestRunner runner = TestRunners.newTestRunner(new FetchS3Object());
+        TestRunner runner = TestRunners.newTestRunner(new FetchS3Object());
 
         runner.setProperty(Properties.REGION, REGION);
         runner.setProperty(Properties.BUCKET, bucketName);
@@ -111,23 +111,23 @@ class FetchS3ObjectTest extends AbstractS3Test {
         runner.setProperty(Properties.ACCESS_KEY_ID, credentials.getAWSAccessKeyId());
         runner.setProperty(Properties.SECRET_ACCESS_KEY, credentials.getAWSSecretKey());
 
-        final Map<String, String> attrs = new HashMap<>();
+        Map<String, String> attrs = new HashMap<>();
         runner.enqueue(new byte[0], attrs);
 
         runner.run(1);
 
 
         Failsafe.with(retryPolicy).run(() -> {
-            final List<MockFlowFile> ffs = runner.getFlowFilesForRelationship(Properties.REL_SUCCESS);
+            List<MockFlowFile> ffs = runner.getFlowFilesForRelationship(Properties.REL_SUCCESS);
             assertThat(ffs).hasSize(1);
             assertThat(ffs).allSatisfy(mff -> assertThat(mff.getAttribute("filename")).contains("folder/1.txt"));
-            final MockFlowFile out = ffs.iterator().next();
+            MockFlowFile out = ffs.iterator().next();
 
-            final byte[] expectedBytes = Files.readAllBytes(getResourcePath(SAMPLE_FILE_RESOURCE_NAME));
+            byte[] expectedBytes = Files.readAllBytes(getResourcePath(SAMPLE_FILE_RESOURCE_NAME));
             out.assertContentEquals(new String(expectedBytes));
 
 
-            for (final Map.Entry<String, String> entry : out.getAttributes().entrySet()) {
+            for (Map.Entry<String, String> entry : out.getAttributes().entrySet()) {
                 System.out.println(entry.getKey() + " : " + entry.getValue());
             }
         });
@@ -143,7 +143,7 @@ class FetchS3ObjectTest extends AbstractS3Test {
         File contents2 = getFileFromResourceName(testfile2);
         putTestFile(testfile2, contents2, bucketName);
 
-        final TestRunner runner = TestRunners.newTestRunner(new FetchS3Object());
+        TestRunner runner = TestRunners.newTestRunner(new FetchS3Object());
 
         runner.setProperty(Properties.REGION, REGION);
         runner.setProperty(Properties.BUCKET, bucketName);
@@ -152,13 +152,13 @@ class FetchS3ObjectTest extends AbstractS3Test {
         runner.setProperty(Properties.SECRET_ACCESS_KEY, credentials.getAWSSecretKey());
 
 
-        final Map<String, String> attrs = new HashMap<>();
+        Map<String, String> attrs = new HashMap<>();
         runner.enqueue(new byte[0], attrs);
 
         runner.run(1);
 
         Failsafe.with(retryPolicy).run(() -> {
-            final List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(Properties.REL_SUCCESS);
+            List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(Properties.REL_SUCCESS);
             assertThat(successfulFlowFiles).hasSize(2);
             assertThat(successfulFlowFiles).allSatisfy(mff -> assertThat(mff.getAttribute("filename")).contains("hello"));
 
@@ -176,7 +176,7 @@ class FetchS3ObjectTest extends AbstractS3Test {
         putTestFile("hello1.txt", contents1, bucketName);
 
 
-        final TestRunner runner = TestRunners.newTestRunner(new FetchS3Object());
+        TestRunner runner = TestRunners.newTestRunner(new FetchS3Object());
 
         runner.setProperty(Properties.REGION, REGION);
         runner.setProperty(Properties.BUCKET, bucketName);
@@ -185,18 +185,18 @@ class FetchS3ObjectTest extends AbstractS3Test {
         runner.setProperty(Properties.SECRET_ACCESS_KEY, credentials.getAWSSecretKey());
 
 
-        final Map<String, String> attrs = new HashMap<>();
+        Map<String, String> attrs = new HashMap<>();
         runner.enqueue(new byte[0], attrs);
 
         runner.run(1);
 
         Failsafe.with(retryPolicy).run(() -> {
-            final List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(Properties.REL_SUCCESS);
+            List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(Properties.REL_SUCCESS);
             assertThat(successfulFlowFiles).hasSize(1);
 
             assertThat(successfulFlowFiles).allSatisfy(mff -> assertThat(mff.getAttribute("filename")).contains("hello1"));
 
-            final List<MockFlowFile> failedFlowFiles = runner.getFlowFilesForRelationship(Properties.REL_FAILURE);
+            List<MockFlowFile> failedFlowFiles = runner.getFlowFilesForRelationship(Properties.REL_FAILURE);
             assertThat(failedFlowFiles).hasSize(1);
         });
 
@@ -212,7 +212,7 @@ class FetchS3ObjectTest extends AbstractS3Test {
         File contents2 = getFileFromResourceName(testfile2);
         putTestFile("file2.txt", contents2, bucketName);
 
-        final TestRunner runner = TestRunners.newTestRunner(new FetchS3Object());
+        TestRunner runner = TestRunners.newTestRunner(new FetchS3Object());
 
         runner.setProperty(Properties.REGION, REGION);
         runner.setProperty(Properties.BUCKET, bucketName);
@@ -220,14 +220,14 @@ class FetchS3ObjectTest extends AbstractS3Test {
         runner.setProperty(Properties.SECRET_ACCESS_KEY, credentials.getAWSSecretKey());
 
 
-        final Map<String, String> attrs = new HashMap<>();
+        Map<String, String> attrs = new HashMap<>();
         runner.enqueue(new byte[0], attrs);
 
         runner.run(1);
 
         Failsafe.with(retryPolicy).run(() -> {
             runner.assertAllFlowFilesTransferred(Properties.REL_SUCCESS);
-            final List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(Properties.REL_SUCCESS);
+            List<MockFlowFile> successfulFlowFiles = runner.getFlowFilesForRelationship(Properties.REL_SUCCESS);
 
             assertThat(successfulFlowFiles).allSatisfy(mff -> assertThat(mff.getAttribute("filename")).isNotEmpty());
 

--- a/external/nifi/processors/src/test/java/microsoft/dagx/transfer/nifi/processors/FetchS3ObjectTest.java
+++ b/external/nifi/processors/src/test/java/microsoft/dagx/transfer/nifi/processors/FetchS3ObjectTest.java
@@ -6,7 +6,6 @@
 
 package microsoft.dagx.transfer.nifi.processors;
 
-import com.amazonaws.auth.AWSCredentials;
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
 import org.apache.nifi.util.MockFlowFile;
@@ -19,7 +18,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
@@ -32,27 +30,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnabledIfEnvironmentVariable(named = "CI", matches = "true")
 class FetchS3ObjectTest extends AbstractS3Test {
 
-    private AWSCredentials credentials;
     private RetryPolicy<Object> retryPolicy;
-    private String bucketName;
 
     @BeforeEach
     void setup() {
-        bucketName = "test-bucket-" + System.currentTimeMillis() + "-" + REGION;
         createBucket(client, bucketName, REGION);
-
-        credentials = getCredentials();
         retryPolicy = new RetryPolicy<>().withBackoff(500, 5000, ChronoUnit.MILLIS).withMaxRetries(5).handle(AssertionError.class);
     }
 
     @AfterEach
-    void cleanup(){
+    void cleanup() {
         deleteBucket(bucketName, client);
     }
 
     @Test
     @DisplayName("Verifies that a file is downloaded and the 'success' relation is traversed")
-    public void testFetchFile_single() throws IOException {
+    public void testFetchFile_single() {
         putTestFile("test-file", getFileFromResourceName(SAMPLE_FILE_RESOURCE_NAME), bucketName);
 
         final TestRunner runner = TestRunners.newTestRunner(new FetchS3Object());
@@ -106,7 +99,7 @@ class FetchS3ObjectTest extends AbstractS3Test {
 
     @Test
     @DisplayName("Downloads a file and compares the contents")
-    public void testFetchFile_single_assertContents() throws IOException {
+    public void testFetchFile_single_assertContents() {
         String key = "folder/1.txt";
         putTestFile(key, getFileFromResourceName(SAMPLE_FILE_RESOURCE_NAME), bucketName);
 
@@ -142,7 +135,7 @@ class FetchS3ObjectTest extends AbstractS3Test {
 
     @Test
     @DisplayName("When a set of files is specified, the processor should fetch those")
-    public void fetchFile_multiple_shouldEnumerate() throws IOException {
+    public void fetchFile_multiple_shouldEnumerate() {
         File contents1 = getFileFromResourceName(SAMPLE_FILE_RESOURCE_NAME);
         putTestFile("hello1.txt", contents1, bucketName);
 
@@ -178,7 +171,7 @@ class FetchS3ObjectTest extends AbstractS3Test {
 
     @Test
     @DisplayName("When a set of files is specified, the processor should fetch those")
-    public void fetchFile_multiple_someDontExist_shouldEnumerate() throws IOException {
+    public void fetchFile_multiple_someDontExist_shouldEnumerate() {
         File contents1 = getFileFromResourceName(SAMPLE_FILE_RESOURCE_NAME);
         putTestFile("hello1.txt", contents1, bucketName);
 
@@ -211,7 +204,7 @@ class FetchS3ObjectTest extends AbstractS3Test {
 
     @Test
     @DisplayName("When no list of files is specified, the processor should enumerate all")
-    public void fetchFile_none_shouldEnumerate() throws IOException {
+    public void fetchFile_none_shouldEnumerate() {
         File contents1 = getFileFromResourceName(SAMPLE_FILE_RESOURCE_NAME);
         putTestFile("file1.txt", contents1, bucketName);
 
@@ -241,5 +234,4 @@ class FetchS3ObjectTest extends AbstractS3Test {
             assertThat(successfulFlowFiles).hasSizeGreaterThanOrEqualTo(2);
         });
     }
-
 }

--- a/external/nifi/processors/src/test/java/microsoft/dagx/transfer/nifi/processors/PutS3ObjectTest.java
+++ b/external/nifi/processors/src/test/java/microsoft/dagx/transfer/nifi/processors/PutS3ObjectTest.java
@@ -10,8 +10,6 @@ import com.amazonaws.services.s3.model.PutObjectResult;
 import com.amazonaws.services.s3.model.S3Object;
 import org.apache.nifi.util.TestRunner;
 import org.apache.nifi.util.TestRunners;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
@@ -24,16 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfEnvironmentVariable(named = "CI", matches = "true")
 public class PutS3ObjectTest extends AbstractS3Test {
-
-    @BeforeEach
-    void setup() {
-        createBucket(bucketName, REGION);
-    }
-
-    @AfterEach
-    void cleanup() {
-        deleteBucket(bucketName, client);
-    }
 
     @Test
     void upload() throws IOException {

--- a/external/nifi/processors/src/test/java/microsoft/dagx/transfer/nifi/processors/PutS3ObjectTest.java
+++ b/external/nifi/processors/src/test/java/microsoft/dagx/transfer/nifi/processors/PutS3ObjectTest.java
@@ -6,7 +6,6 @@
 
 package microsoft.dagx.transfer.nifi.processors;
 
-import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.services.s3.model.PutObjectResult;
 import com.amazonaws.services.s3.model.S3Object;
 import org.apache.nifi.util.TestRunner;
@@ -25,20 +24,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfEnvironmentVariable(named = "CI", matches = "true")
 public class PutS3ObjectTest extends AbstractS3Test {
-    private AWSCredentials credentials;
-    private String bucketName ;
 
     @BeforeEach
     void setup() {
-        bucketName = "test-bucket-" + System.currentTimeMillis() + "-" + REGION;
         createBucket(client, bucketName, REGION);
-        credentials = getCredentials();
     }
 
     @AfterEach
-    void cleanup(){
+    void cleanup() {
         deleteBucket(bucketName, client);
     }
+
     @Test
     void upload() throws IOException {
         String key = "test-file.txt";
@@ -87,6 +83,5 @@ public class PutS3ObjectTest extends AbstractS3Test {
         assertThat(new String(newS3Object.getObjectContent().readAllBytes())).isEqualTo(newContent);
         assertThat(newS3Object.getObjectMetadata().getETag()).isNotEqualTo(response.getETag());
     }
-
 
 }

--- a/external/nifi/processors/src/test/java/microsoft/dagx/transfer/nifi/processors/PutS3ObjectTest.java
+++ b/external/nifi/processors/src/test/java/microsoft/dagx/transfer/nifi/processors/PutS3ObjectTest.java
@@ -27,7 +27,7 @@ public class PutS3ObjectTest extends AbstractS3Test {
 
     @BeforeEach
     void setup() {
-        createBucket(client, bucketName, REGION);
+        createBucket(bucketName, REGION);
     }
 
     @AfterEach
@@ -38,7 +38,7 @@ public class PutS3ObjectTest extends AbstractS3Test {
     @Test
     void upload() throws IOException {
         String key = "test-file.txt";
-        final TestRunner runner = TestRunners.newTestRunner(new PutS3Object());
+        TestRunner runner = TestRunners.newTestRunner(new PutS3Object());
 
         runner.setProperty(Properties.REGION, REGION);
         runner.setProperty(Properties.BUCKET, bucketName);
@@ -47,7 +47,7 @@ public class PutS3ObjectTest extends AbstractS3Test {
         runner.setProperty(Properties.SECRET_ACCESS_KEY, credentials.getAWSSecretKey());
 
 
-        final Map<String, String> attrs = new HashMap<>();
+        Map<String, String> attrs = new HashMap<>();
         runner.enqueue(getResourcePath(SAMPLE_FILE_RESOURCE_NAME), attrs);
         runner.enqueue(getResourcePath(SAMPLE_FILE_RESOURCE_NAME), attrs);
         runner.enqueue(getResourcePath(SAMPLE_FILE_RESOURCE_NAME), attrs);
@@ -62,7 +62,7 @@ public class PutS3ObjectTest extends AbstractS3Test {
         String key = "test-file.txt";
         PutObjectResult response = putTestFile(key, getFileFromResourceName(SAMPLE_FILE_RESOURCE_NAME), bucketName);
 
-        final TestRunner runner = TestRunners.newTestRunner(new PutS3Object());
+        TestRunner runner = TestRunners.newTestRunner(new PutS3Object());
 
         runner.setProperty(Properties.REGION, REGION);
         runner.setProperty(Properties.BUCKET, bucketName);
@@ -71,7 +71,7 @@ public class PutS3ObjectTest extends AbstractS3Test {
         runner.setProperty(Properties.SECRET_ACCESS_KEY, credentials.getAWSSecretKey());
 
 
-        final Map<String, String> attrs = new HashMap<>();
+        Map<String, String> attrs = new HashMap<>();
         String newContent = "this is another content!";
         runner.enqueue(newContent, attrs);
 


### PR DESCRIPTION
re-using the same bucket for all the nifi tests seemed to provoke some weird and sporadic timing issues. I therefore implemented the creation and deletion of a bucket in the `@BeforeEach` and `@AfterEach` respectively. While this is certainly cleaner, we should keep an eye on S3 bucket quota.