### PR TITLE
Feature/63 implement deprovisioning

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -86,12 +86,13 @@ jobs:
         id: validate
         run: terraform -chdir=scripts validate -no-color
 
-      - name: Terraform Plan
-        id: plan
-        if: github.event_name == 'pull_request'
-        run: terraform -chdir=scripts plan -no-color -var "resourcesuffix=dev" -var "backend_account_key=${{ secrets.TF_BACKEND_KEY }}"
+      #     deactivated until the GithubActions-User has correct credentials
+#      - name: Terraform Plan
+#        id: plan
+#        if: github.event_name == 'pull_request'
+#        run: terraform -chdir=scripts plan -no-color -var "resourcesuffix=dev" -var "backend_account_key=${{ secrets.TF_BACKEND_KEY }}"
 
-#     deactivated until the GithubActions-User has correct credentials
+
 
 #      - name: Taint the connector instance
 #        if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/distributions/demo-e2e/dagx-config-docker.properties
+++ b/distributions/demo-e2e/dagx-config-docker.properties
@@ -7,7 +7,7 @@ dagx.vault.clientid=<YOUR_SERVICEPRINCIPAL_CLIENTID>
 dagx.vault.tenantid=<YOUR_SUBSCRIPTION_TENANTID>
 # that must be the same certificate that was used during "terraform apply" for the primary service principal!
 dagx.vault.certificate=./cert.pfx
-dagx.vault.name=dagx-demo-vault
+dagx.vault.name=dagx-dev-vault
 dagx.atlas.url=https://dev-dagx-atlas.westeurope.cloudapp.azure.com
 dagx.nifi.url=http://dev-dagx-nifi.westeurope.azurecontainer.io:8080/
 dagx.nifi.flow.url=http://dev-dagx-nifi.westeurope.azurecontainer.io:8888/

--- a/extensions/transfer/transfer-core/src/main/java/com/microsoft/dagx/transfer/core/CoreTransferExtension.java
+++ b/extensions/transfer/transfer-core/src/main/java/com/microsoft/dagx/transfer/core/CoreTransferExtension.java
@@ -11,6 +11,7 @@ import com.microsoft.dagx.spi.security.Vault;
 import com.microsoft.dagx.spi.system.ServiceExtension;
 import com.microsoft.dagx.spi.system.ServiceExtensionContext;
 import com.microsoft.dagx.spi.transfer.TransferProcessManager;
+import com.microsoft.dagx.spi.transfer.TransferProcessObservable;
 import com.microsoft.dagx.spi.transfer.TransferWaitStrategy;
 import com.microsoft.dagx.spi.transfer.flow.DataFlowManager;
 import com.microsoft.dagx.spi.transfer.provision.ProvisionManager;
@@ -84,6 +85,7 @@ public class CoreTransferExtension implements ServiceExtension {
                 .build();
 
         context.registerService(TransferProcessManager.class, processManager);
+        context.registerService(TransferProcessObservable.class, processManager);
 
         monitor.info("Initialized Core Transfer extension");
     }

--- a/extensions/transfer/transfer-core/src/main/java/com/microsoft/dagx/transfer/core/provision/ProvisionContextImpl.java
+++ b/extensions/transfer/transfer-core/src/main/java/com/microsoft/dagx/transfer/core/provision/ProvisionContextImpl.java
@@ -21,14 +21,17 @@ import java.util.function.Consumer;
 public class ProvisionContextImpl implements ProvisionContext {
     private final Consumer<ProvisionedResource> resourceCallback;
     private final BiConsumer<ProvisionedDataDestinationResource, SecretToken> destinationCallback;
+    private final BiConsumer<ProvisionedDataDestinationResource, Throwable> deprovisionCallback;
     private final TransferProcessStore processStore;
 
     public ProvisionContextImpl(TransferProcessStore processStore,
                                 Consumer<ProvisionedResource> resourceCallback,
-                                BiConsumer<ProvisionedDataDestinationResource, SecretToken> destinationCallback) {
+                                BiConsumer<ProvisionedDataDestinationResource, SecretToken> destinationCallback,
+                                BiConsumer<ProvisionedDataDestinationResource, Throwable> deprovisionCallback) {
         this.processStore = processStore;
         this.resourceCallback = resourceCallback;
         this.destinationCallback = destinationCallback;
+        this.deprovisionCallback = deprovisionCallback;
     }
 
     @Override
@@ -39,6 +42,11 @@ public class ProvisionContextImpl implements ProvisionContext {
     @Override
     public void callback(ProvisionedDataDestinationResource resource, SecretToken secretToken) {
         destinationCallback.accept(resource, secretToken);
+    }
+
+    @Override
+    public void deprovisioned(ProvisionedDataDestinationResource resource, Throwable error) {
+        deprovisionCallback.accept(resource, error);
     }
 
     @Override

--- a/extensions/transfer/transfer-core/src/test/java/com/microsoft/dagx/transfer/core/transfer/TransferProcessManagerImplTest.java
+++ b/extensions/transfer/transfer-core/src/test/java/com/microsoft/dagx/transfer/core/transfer/TransferProcessManagerImplTest.java
@@ -7,6 +7,7 @@ package com.microsoft.dagx.transfer.core.transfer;
 
 import com.microsoft.dagx.spi.message.RemoteMessageDispatcherRegistry;
 import com.microsoft.dagx.spi.monitor.Monitor;
+import com.microsoft.dagx.spi.transfer.TransferProcessListener;
 import com.microsoft.dagx.spi.transfer.flow.DataFlowManager;
 import com.microsoft.dagx.spi.transfer.provision.ProvisionManager;
 import com.microsoft.dagx.spi.transfer.provision.ResourceManifestGenerator;
@@ -15,10 +16,12 @@ import com.microsoft.dagx.spi.types.domain.transfer.DataRequest;
 import com.microsoft.dagx.spi.types.domain.transfer.StatusCheckerRegistry;
 import com.microsoft.dagx.spi.types.domain.transfer.TransferProcess;
 import org.easymock.EasyMock;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.niceMock;
 
@@ -28,12 +31,13 @@ import static org.easymock.EasyMock.niceMock;
 class TransferProcessManagerImplTest {
 
 
-    /**
-     * All creations operations must be idempotent in order to support reliability (e.g. messages/requests may be delivered more than once).
-     */
-    @Test
-    void verifyIdempotency() {
-        TransferProcessStore store = EasyMock.createMock(TransferProcessStore.class);
+    private TransferProcessManagerImpl manager;
+    private TransferProcessStore store;
+
+
+    @BeforeEach
+    void setup() {
+        store = EasyMock.createMock(TransferProcessStore.class);
 
         EasyMock.expect(store.processIdForTransferId("1")).andReturn(null);  // first invoke returns no as there is no store process
 
@@ -46,25 +50,95 @@ class TransferProcessManagerImplTest {
 
         EasyMock.replay(store);
 
-        TransferProcessManagerImpl manager = TransferProcessManagerImpl.Builder.newInstance()
+        manager = TransferProcessManagerImpl.Builder.newInstance()
                 .dispatcherRegistry(createNiceMock(RemoteMessageDispatcherRegistry.class))
                 .provisionManager(createNiceMock(ProvisionManager.class))
                 .dataFlowManager(createNiceMock(DataFlowManager.class))
                 .monitor(createNiceMock(Monitor.class))
                 .statusCheckerRegistry(niceMock(StatusCheckerRegistry.class))
                 .manifestGenerator(createNiceMock(ResourceManifestGenerator.class)).build();
-
         manager.start(store);
+    }
+
+    /**
+     * All creations operations must be idempotent in order to support reliability (e.g. messages/requests may be delivered more than once).
+     */
+    @Test
+    void verifyIdempotency() {
 
         DataRequest dataRequest = DataRequest.Builder.newInstance().id("1").destinationType("test").build();
-
         manager.initiateProviderRequest(dataRequest);
 
         // repeat request
         manager.initiateProviderRequest(dataRequest);
-
         manager.stop();
-
         EasyMock.verify(store); // verify the process was only stored once
+    }
+
+    @Test
+    void registerListener() {
+        var listener = new TestListener();
+        manager.registerListener("test-process", listener);
+
+        assertThat(manager.getListeners()).containsKey("test-process");
+        assertThat(manager.getListeners().get("test-process")).containsOnly(listener);
+    }
+
+    @Test
+    void registerListener_processIdExists_shouldAdd() {
+        var listener = new TestListener();
+        var listener2 = new TestListener();
+        manager.registerListener("test-process", listener);
+        manager.registerListener("test-process", listener2);
+
+        assertThat(manager.getListeners()).containsKey("test-process");
+        assertThat(manager.getListeners().get("test-process")).hasSize(2).containsOnly(listener, listener2);
+    }
+
+    @Test
+    void registerListener_processIdAndListenerExists_shouldReplace() {
+        var listener = new TestListener();
+        manager.registerListener("test-process", listener);
+        manager.registerListener("test-process", listener);
+
+        assertThat(manager.getListeners()).containsKey("test-process");
+        assertThat(manager.getListeners().get("test-process")).hasSize(1).containsOnly(listener);
+    }
+
+    @Test
+    void unregisterListener() {
+        var listener = new TestListener();
+        var pid = "test-pid";
+        manager.registerListener(pid, listener);
+
+        manager.unregister(listener);
+
+        assertThat(manager.getListeners()).doesNotContainKey(pid);
+    }
+
+
+    @Test
+    void unregisterListener_listenerNotRegistered() {
+        var listener = new TestListener();
+        var pid = "test-pid";
+        manager.registerListener(pid, listener);
+
+        var listener2 = new TestListener();
+        manager.unregister(listener2);
+
+        assertThat(manager.getListeners()).containsKey(pid);
+        assertThat(manager.getListeners().get(pid)).doesNotContain(listener2).containsOnly(listener);
+    }
+
+    private static class TestListener implements TransferProcessListener {
+        @Override
+        public void completed(TransferProcess process) {
+
+        }
+
+        @Override
+        public void deprovisioned(TransferProcess process) {
+
+        }
     }
 }

--- a/extensions/transfer/transfer-provision-aws/src/main/java/com/microsoft/dagx/transfer/provision/aws/s3/S3BucketProvisionedResource.java
+++ b/extensions/transfer/transfer-provision-aws/src/main/java/com/microsoft/dagx/transfer/provision/aws/s3/S3BucketProvisionedResource.java
@@ -27,6 +27,8 @@ public class S3BucketProvisionedResource extends ProvisionedDataDestinationResou
 
     @JsonProperty
     private String bucketName;
+    @JsonProperty
+    private String role;
 
     private S3BucketProvisionedResource() {
     }
@@ -54,6 +56,10 @@ public class S3BucketProvisionedResource extends ProvisionedDataDestinationResou
         return bucketName;
     }
 
+    public String getRole() {
+        return role;
+    }
+
 
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder extends ProvisionedDataDestinationResource.Builder<S3BucketProvisionedResource, Builder> {
@@ -74,6 +80,11 @@ public class S3BucketProvisionedResource extends ProvisionedDataDestinationResou
 
         public Builder bucketName(String bucketName) {
             provisionedResource.bucketName = bucketName;
+            return this;
+        }
+
+        public Builder role(String arn) {
+            provisionedResource.role = arn;
             return this;
         }
     }

--- a/extensions/transfer/transfer-provision-aws/src/main/java/com/microsoft/dagx/transfer/provision/aws/s3/S3BucketProvisioner.java
+++ b/extensions/transfer/transfer-provision-aws/src/main/java/com/microsoft/dagx/transfer/provision/aws/s3/S3BucketProvisioner.java
@@ -67,6 +67,11 @@ public class S3BucketProvisioner implements Provisioner<S3BucketResourceDefiniti
 
     @Override
     public ResponseStatus deprovision(S3BucketProvisionedResource provisionedResource) {
+        final S3DeprovisionPipeline pipeline = S3DeprovisionPipeline.Builder.newInstance().clientProvider(clientProvider)
+                .retryPolicy(retryPolicy)
+                .monitor(monitor)
+                .resource().build();
+        pipeline.deprovision(provisionedResource, throwable -> context.deprovisioned(provisionedResource, throwable));
         return ResponseStatus.OK;
     }
 

--- a/extensions/transfer/transfer-provision-aws/src/main/java/com/microsoft/dagx/transfer/provision/aws/s3/S3DeprovisionPipeline.java
+++ b/extensions/transfer/transfer-provision-aws/src/main/java/com/microsoft/dagx/transfer/provision/aws/s3/S3DeprovisionPipeline.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *  All rights reserved.
+ *
+ */
+
+package com.microsoft.dagx.transfer.provision.aws.s3;
+
+import com.microsoft.dagx.spi.monitor.Monitor;
+import com.microsoft.dagx.transfer.provision.aws.provider.ClientProvider;
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
+import software.amazon.awssdk.services.iam.IamAsyncClient;
+import software.amazon.awssdk.services.iam.model.DeleteRolePolicyRequest;
+import software.amazon.awssdk.services.iam.model.DeleteRoleRequest;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.*;
+
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+public class S3DeprovisionPipeline {
+    private final ClientProvider clientProvider;
+    private final RetryPolicy<Object> retryPolicy;
+
+    private final Monitor monitor;
+
+    public S3DeprovisionPipeline(ClientProvider clientProvider, RetryPolicy<Object> retryPolicy, Monitor monitor) {
+        this.clientProvider = clientProvider;
+        this.retryPolicy = retryPolicy;
+        this.monitor = monitor;
+    }
+
+    public void deprovision(S3BucketProvisionedResource resource, Consumer<Throwable> callback) {
+        var s3Client = clientProvider.clientFor(S3AsyncClient.class, resource.getRegion());
+        var iamClient = clientProvider.clientFor(IamAsyncClient.class, resource.getRegion());
+
+        final String bucketName = resource.getBucketName();
+
+        monitor.info("S3 Deprovisioning: list bucket contents");
+        final String role = resource.getRole();
+        s3Client.listObjectsV2(listBucket(bucketName))
+                .thenCompose(listObjectsResponse -> {
+                    //todo: collect identifiers into a single request using the stream api
+                    var identifiers = listObjectsResponse.contents().stream()
+                            .map(s3object -> ObjectIdentifier.builder().key(s3object.key()).build())
+                            .collect(Collectors.toList());
+                    var deleteRequest = DeleteObjectsRequest.builder().bucket(bucketName).delete(Delete.builder().objects(identifiers).build()).build();
+                    monitor.info("S3 Deprovisioning: delete bucket contents: " + identifiers.stream().map(ObjectIdentifier::key).collect(Collectors.joining(", ")));
+                    return s3Client.deleteObjects(deleteRequest);
+                })
+                .thenCompose(deleteObjectsResponse -> Failsafe.with(retryPolicy).getStageAsync(() -> {
+                    monitor.info("S3 Deprovisioning: delete bucket");
+                    return s3Client.deleteBucket(deleteBucket(bucketName));
+                }))
+                .thenCompose(listAttachedRolePoliciesResponse -> Failsafe.with(retryPolicy).getStageAsync(() -> {
+                    monitor.info("S3 Deprovisioning: deleting inline policies for Role " + role);
+                    return iamClient.deleteRolePolicy(DeleteRolePolicyRequest.builder().roleName(role).policyName(role).build());
+                }))
+                .thenCompose(deleteRolePolicyResponse -> Failsafe.with(retryPolicy).getStageAsync(() -> {
+                    monitor.info("S3 Deprovisioning: delete role");
+                    return iamClient.deleteRole(DeleteRoleRequest.builder().roleName(role).build());
+                }))
+                .whenComplete((deleteRoleResponse, throwable) -> callback.accept(throwable));
+    }
+
+    private DeleteBucketRequest deleteBucket(String bucketName) {
+        return DeleteBucketRequest.builder().bucket(bucketName).build();
+    }
+
+    private ListObjectsV2Request listBucket(String bucketName) {
+        return ListObjectsV2Request.builder().bucket(bucketName).build();
+    }
+
+
+    public static final class Builder {
+        private ClientProvider clientProvider;
+        private RetryPolicy<Object> retryPolicy;
+        private Monitor monitor;
+
+        private Builder() {
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder clientProvider(ClientProvider clientProvider) {
+            this.clientProvider = clientProvider;
+            return this;
+        }
+
+        public Builder retryPolicy(RetryPolicy<Object> retryPolicy) {
+            this.retryPolicy = retryPolicy;
+            return this;
+        }
+
+        public S3DeprovisionPipeline build() {
+            return new S3DeprovisionPipeline(clientProvider, retryPolicy, monitor);
+        }
+
+        public Builder resource() {
+            return this;
+        }
+
+        public Builder monitor(Monitor monitor) {
+            this.monitor = monitor;
+            return this;
+        }
+    }
+}

--- a/extensions/transfer/transfer-provision-aws/src/test/java/com/microsoft/dagx/transfer/provision/aws/s3/S3BucketProvisionerTest.java
+++ b/extensions/transfer/transfer-provision-aws/src/test/java/com/microsoft/dagx/transfer/provision/aws/s3/S3BucketProvisionerTest.java
@@ -85,6 +85,12 @@ class S3BucketProvisionerTest {
             public void callback(ProvisionedDataDestinationResource resource, @Nullable SecretToken secretToken) {
                 latch.countDown();
             }
+
+            @Override
+            public void deprovisioned(ProvisionedDataDestinationResource resource, Throwable error) {
+                // noop here
+            }
+
         });
 
         provisioner.provision(S3BucketResourceDefinition.Builder.newInstance().id("test").regionId(Region.US_EAST_1.id()).bucketName("test").transferProcessId("test").build());

--- a/extensions/transfer/transfer-provision-azure/src/main/java/com/microsoft/dagx/transfer/provision/azure/blob/ObjectStorageProvisioner.java
+++ b/extensions/transfer/transfer-provision-azure/src/main/java/com/microsoft/dagx/transfer/provision/azure/blob/ObjectStorageProvisioner.java
@@ -88,6 +88,14 @@ public class ObjectStorageProvisioner implements Provisioner<ObjectStorageResour
 
     @Override
     public ResponseStatus deprovision(ObjectContainerProvisionedResource provisionedResource) {
+        Throwable throwable = null;
+        try {
+            with(retryPolicy).run(() -> blobStoreApi.deleteContainer(provisionedResource.getAccountName(), provisionedResource.getContainerName()));
+        } catch (Exception ex) {
+            throwable = ex;
+        }
+        //the sas token will expire automatically. there is no way of revoking them other than a stored access policy
+        context.deprovisioned(provisionedResource, throwable);
         return ResponseStatus.OK;
     }
 }

--- a/integration/integration-core/src/test/java/ClientRunner.java
+++ b/integration/integration-core/src/test/java/ClientRunner.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -51,7 +50,7 @@ public class ClientRunner {
     private CountDownLatch latch;
 
     @Test
-//    @Disabled
+    @Disabled
     void processClientRequest_toAws(RemoteMessageDispatcherRegistry dispatcherRegistry, TransferProcessManager processManager, TransferProcessObservable observable, TransferProcessStore store) throws Exception {
 
         var query = QueryRequest.Builder.newInstance()
@@ -64,7 +63,6 @@ public class ClientRunner {
         CompletableFuture<List<String>> future = cast(dispatcherRegistry.send(List.class, query, () -> null));
 
         var artifacts = future.get();
-        artifacts = Collections.singletonList(artifacts.get(0));
         latch = new CountDownLatch(artifacts.size());
         for (String artifact : artifacts) {
             System.out.println("processing artifact " + artifact);
@@ -93,9 +91,9 @@ public class ClientRunner {
         }
 
         // Initiate a request as a U.S.-based connector for an EU-restricted artifact (will be denied)
-        var usRequest = createRequestAws("us-request", EU_ARTIFACT);
-
-        processManager.initiateClientRequest(usRequest);
+//        var usRequest = createRequestAws("us-request", EU_ARTIFACT);
+//
+//        processManager.initiateClientRequest(usRequest);
 
 
         assertThat(latch.await(5, TimeUnit.MINUTES)).isTrue();
@@ -103,7 +101,7 @@ public class ClientRunner {
 
 
     @Test
-//    @Disabled
+    @Disabled
     void processClientRequest_toAzureStorage(RemoteMessageDispatcherRegistry dispatcherRegistry, TransferProcessManager processManager, TransferProcessObservable observable, TransferProcessStore store) throws Exception {
         var query = QueryRequest.Builder.newInstance()
                 .connectorAddress(PROVIDER_CONNECTOR)
@@ -118,7 +116,6 @@ public class ClientRunner {
 
         assertThat(artifacts).describedAs("Should have returned artifacts!").isNotEmpty();
 
-        artifacts = Collections.singletonList(artifacts.get(0));
         latch = new CountDownLatch(artifacts.size());
 
         for (String artifact : artifacts) {
@@ -147,9 +144,9 @@ public class ClientRunner {
         }
 
         // Initiate a request as a U.S.-based connector for an EU-restricted artifact (will be denied)
-        var usRequest = createRequestAzure("us-request", EU_ARTIFACT);
-
-        processManager.initiateClientRequest(usRequest);
+//        var usRequest = createRequestAzure("us-request", EU_ARTIFACT);
+//
+//        processManager.initiateClientRequest(usRequest);
 
         assertThat(latch.await(5, TimeUnit.MINUTES)).isTrue();
     }
@@ -184,7 +181,7 @@ public class ClientRunner {
                 .dataDestination(DataAddress.Builder.newInstance()
                         .type(AzureBlobStoreSchema.TYPE)
                         .property(AzureBlobStoreSchema.ACCOUNT_NAME, "dagxtfblob")
-                        .property(AzureBlobStoreSchema.CONTAINER_NAME, "temp-dest-container")
+                        .property(AzureBlobStoreSchema.CONTAINER_NAME, "temp-dest-container-" + UUID.randomUUID())
                         .build())
                 .destinationType(AzureBlobStoreSchema.TYPE)
                 .build();

--- a/spi/src/main/java/com/microsoft/dagx/spi/Observable.java
+++ b/spi/src/main/java/com/microsoft/dagx/spi/Observable.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *  All rights reserved.
+ *
+ */
+
+package com.microsoft.dagx.spi;
+
+public interface Observable<T> {
+    void unregister(T listener);
+}

--- a/spi/src/main/java/com/microsoft/dagx/spi/transfer/TransferProcessListener.java
+++ b/spi/src/main/java/com/microsoft/dagx/spi/transfer/TransferProcessListener.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *  All rights reserved.
+ *
+ */
+
+package com.microsoft.dagx.spi.transfer;
+
+import com.microsoft.dagx.spi.types.domain.transfer.TransferProcess;
+
+public interface TransferProcessListener {
+    default void completed(TransferProcess process) {
+    }
+
+    default void deprovisioned(TransferProcess process) {
+    }
+}

--- a/spi/src/main/java/com/microsoft/dagx/spi/transfer/TransferProcessObservable.java
+++ b/spi/src/main/java/com/microsoft/dagx/spi/transfer/TransferProcessObservable.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *  All rights reserved.
+ *
+ */
+
+package com.microsoft.dagx.spi.transfer;
+
+import com.microsoft.dagx.spi.Observable;
+
+public interface TransferProcessObservable extends Observable<TransferProcessListener> {
+    void registerListener(String processId, TransferProcessListener listener);
+}

--- a/spi/src/main/java/com/microsoft/dagx/spi/transfer/provision/ProvisionContext.java
+++ b/spi/src/main/java/com/microsoft/dagx/spi/transfer/provision/ProvisionContext.java
@@ -26,6 +26,14 @@ public interface ProvisionContext {
     void callback(ProvisionedDataDestinationResource resource, @Nullable SecretToken secretToken);
 
     /**
+     * Invoked when the deprovisioning has completed.
+     *
+     * @param resource The resource that was deprovisioned
+     * @param error    If an error happened during deprovisioning.
+     */
+    void deprovisioned(ProvisionedDataDestinationResource resource, Throwable error);
+
+    /**
      * Persists data related to a provision request.  Data will be removed after all resources have been provisioned for a transfer process.
      * <p>
      * This is intended as a facility to use for recovery. For example, infrastructure request ids can be persisted and recovered to continue processing after runtime restart.

--- a/spi/src/main/java/com/microsoft/dagx/spi/types/domain/transfer/TransferProcess.java
+++ b/spi/src/main/java/com/microsoft/dagx/spi/types/domain/transfer/TransferProcess.java
@@ -182,12 +182,20 @@ public class TransferProcess {
     }
 
     public void transitionDeprovisioning() {
-        transition(TransferProcessStates.DEPROVISIONING, TransferProcessStates.COMPLETED, TransferProcessStates.DEPROVISIONING);
+        transition(TransferProcessStates.DEPROVISIONING, TransferProcessStates.COMPLETED, TransferProcessStates.DEPROVISIONING, TransferProcessStates.DEPROVISIONING_REQ);
     }
 
     public void transitionDeprovisioned() {
         transition(TransferProcessStates.DEPROVISIONED, TransferProcessStates.DEPROVISIONING, TransferProcessStates.DEPROVISIONED);
     }
+
+    /**
+     * Indicates that the transfer process is completed and that it should be deprovisioned
+     */
+    public void transitionDeprovisionRequested() {
+        transition(TransferProcessStates.DEPROVISIONING_REQ, TransferProcessStates.COMPLETED, TransferProcessStates.ERROR, TransferProcessStates.DEPROVISIONING_REQ);
+    }
+
 
     public void transitionEnded() {
         transition(TransferProcessStates.ENDED, TransferProcessStates.DEPROVISIONED);

--- a/spi/src/main/java/com/microsoft/dagx/spi/types/domain/transfer/TransferProcess.java
+++ b/spi/src/main/java/com/microsoft/dagx/spi/types/domain/transfer/TransferProcess.java
@@ -193,7 +193,7 @@ public class TransferProcess {
      * Indicates that the transfer process is completed and that it should be deprovisioned
      */
     public void transitionDeprovisionRequested() {
-        transition(TransferProcessStates.DEPROVISIONING_REQ, TransferProcessStates.COMPLETED, TransferProcessStates.ERROR, TransferProcessStates.DEPROVISIONING_REQ);
+        transition(TransferProcessStates.DEPROVISIONING_REQ, TransferProcessStates.COMPLETED, TransferProcessStates.DEPROVISIONING_REQ);
     }
 
 

--- a/spi/src/main/java/com/microsoft/dagx/spi/types/domain/transfer/TransferProcessStates.java
+++ b/spi/src/main/java/com/microsoft/dagx/spi/types/domain/transfer/TransferProcessStates.java
@@ -21,6 +21,7 @@ public enum TransferProcessStates {
     STREAMING(700),
     COMPLETED(800),
     DEPROVISIONING(900),
+    DEPROVISIONING_REQ(901),
     DEPROVISIONED(1000),
     ENDED(1100),
     ERROR(-1);


### PR DESCRIPTION
Added functionality to deprovision (=delete) 
- Azure Blob Containers
- AWS S3 Buckets + their associated temporary credentials.

Deprovisioning is not done automatically by the `TransferManager`, it must be triggered by calling:
```java
transferProcess.transitionDeprovisionRequested();
transferProcessStore.update(process);
```
Then the `TransferManager` picks up the process and deprovisions all its associated resources. Once that's done it notifies all listeners via the `TransferProcessListener#deprovisioned()` signal.

In order to run a test, comment out any of the `@Disabled` annotations in `ClientRunner.java`. That simulates 