### PR TITLE
Feature/100 implement cosmos based transferprocessstore

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -58,7 +58,8 @@ jobs:
   terraform:
     name: 'Terraform'
     runs-on: ubuntu-latest
-    environment: production
+    environment: dev
+
     env:
       ARM_CLIENT_ID: ${{ secrets.AZURE_AD_CIENT_ID }}
       ARM_CLIENT_SECRET: ${{ secrets.AZURE_AD_CLIENT_SECRET }}

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -44,15 +44,15 @@
 
 name: 'Terraform'
 
+# on:
+#   workflow_run:
+#     workflows: [ "Build Docker Images" ]
+#     types: [ completed ]
 on:
-  #  push:
-  #    branches:
-  #      - main
-  #  pull_request:
-  workflow_run:
-    workflows: [ "Build Docker Images" ]
-    #    branches: [ main ]
-    types: [ completed ]
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   terraform:

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -45,10 +45,14 @@
 name: 'Terraform'
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  #  push:
+  #    branches:
+  #      - main
+  #  pull_request:
+  workflow_run:
+    workflows: [ "Build Docker Images" ]
+    branches: [ main ]
+    types: [ completed ]
 
 jobs:
   terraform:
@@ -86,19 +90,19 @@ jobs:
         id: validate
         run: terraform -chdir=scripts validate -no-color
 
-      #     deactivated until the GithubActions-User has correct credentials
       - name: Terraform Plan
         id: plan
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.workflow_run.conclusion == 'success'
         run: terraform -chdir=scripts plan -no-color -var "resourcesuffix=dev" -var "backend_account_key=${{ secrets.TF_BACKEND_KEY }}"
 
 
+      - name: Taint the connector instance
+        id: taint
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push' && github.event.workflow_run.conclusion == 'success'
+        run: terraform -chdir=scripts taint azurerm_container_group.connector-instance
+        continue-on-error: true
 
-#      - name: Taint the connector instance
-#        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-#        run: terraform -chdir=scripts taint azurerm_container_group.connector-instance
-#        continue-on-error: true
-#
-#      - name: Terraform Apply
-#        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-#        run: terraform -chdir=scripts apply -var "resourcesuffix=dev" -var "backend_account_key=${{ secrets.TF_BACKEND_KEY }}" -auto-approve
+      - name: Terraform Apply
+        id: apply
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push' && github.event.workflow_run.conclusion == 'success'
+        run: terraform -chdir=scripts apply -var "resourcesuffix=dev" -var "backend_account_key=${{ secrets.TF_BACKEND_KEY }}" -auto-approve

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -92,17 +92,16 @@ jobs:
 
       - name: Terraform Plan
         id: plan
-        if: github.event_name == 'pull_request' && github.event.workflow_run.conclusion == 'success'
         run: terraform -chdir=scripts plan -no-color -var "resourcesuffix=dev" -var "backend_account_key=${{ secrets.TF_BACKEND_KEY }}"
 
 
       - name: Taint the connector instance
         id: taint
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push' && github.event.workflow_run.conclusion == 'success'
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: terraform -chdir=scripts taint azurerm_container_group.connector-instance
         continue-on-error: true
 
       - name: Terraform Apply
         id: apply
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push' && github.event.workflow_run.conclusion == 'success'
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: terraform -chdir=scripts apply -var "resourcesuffix=dev" -var "backend_account_key=${{ secrets.TF_BACKEND_KEY }}" -auto-approve

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -51,7 +51,7 @@ on:
   #  pull_request:
   workflow_run:
     workflows: [ "Build Docker Images" ]
-    branches: [ main ]
+    #    branches: [ main ]
     types: [ completed ]
 
 jobs:

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -86,11 +86,10 @@ jobs:
         id: validate
         run: terraform -chdir=scripts validate -no-color
 
-      #     deactivated until the GithubActions-User has correct credentials
-#      - name: Terraform Plan
-#        id: plan
-#        if: github.event_name == 'pull_request'
-#        run: terraform -chdir=scripts plan -no-color -var "resourcesuffix=dev" -var "backend_account_key=${{ secrets.TF_BACKEND_KEY }}"
+      - name: Terraform Plan
+        id: plan
+        if: github.event_name == 'pull_request'
+        run: terraform -chdir=scripts plan -no-color -var "resourcesuffix=dev" -var "backend_account_key=${{ secrets.TF_BACKEND_KEY }}"
 
 
 

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -87,10 +87,10 @@ jobs:
         run: terraform -chdir=scripts validate -no-color
 
       #     deactivated until the GithubActions-User has correct credentials
-#      - name: Terraform Plan
-#        id: plan
-#        if: github.event_name == 'pull_request'
-#        run: terraform -chdir=scripts plan -no-color -var "resourcesuffix=dev" -var "backend_account_key=${{ secrets.TF_BACKEND_KEY }}"
+      - name: Terraform Plan
+        id: plan
+        if: github.event_name == 'pull_request'
+        run: terraform -chdir=scripts plan -no-color -var "resourcesuffix=dev" -var "backend_account_key=${{ secrets.TF_BACKEND_KEY }}"
 
 
 

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -86,10 +86,11 @@ jobs:
         id: validate
         run: terraform -chdir=scripts validate -no-color
 
-      - name: Terraform Plan
-        id: plan
-        if: github.event_name == 'pull_request'
-        run: terraform -chdir=scripts plan -no-color -var "resourcesuffix=dev" -var "backend_account_key=${{ secrets.TF_BACKEND_KEY }}"
+      #     deactivated until the GithubActions-User has correct credentials
+#      - name: Terraform Plan
+#        id: plan
+#        if: github.event_name == 'pull_request'
+#        run: terraform -chdir=scripts plan -no-color -var "resourcesuffix=dev" -var "backend_account_key=${{ secrets.TF_BACKEND_KEY }}"
 
 
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -89,12 +89,13 @@ jobs:
         run: ./gradlew external:nifi:processors:check
 
       - name: Test Azure Vault Integration
+        if: ${{ false }} # disabled for now, because it's VERY slow
         id: azure-vault-tests
         env:
           AZ_STORAGE_SAS: ${{ secrets.AZ_STORAGE_SAS }}
         run: ./gradlew extensions:security:security-azure:check
 
-      - name: Test CosmosTransferProcessStore
+      - name: Test Cosmos-based TransferProcessStore
         id: cosmos-transferprocessstore-test
         env:
           COSMOS_KEY: ${{ secrets.COSMOS_DB_MASTERKEY }}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -22,7 +22,7 @@ jobs:
           NIFI_API_AUTH: ${{ secrets.NIFI_API_AUTH }}
           S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
           S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
-        run: ./gradlew clean check -x :extensions:catalog:catalog-atlas:check -x :extensions:security:security-azure:check  -x :extensions:transfer:transfer-nifi:check -x :external:nifi:processors:check -x extensions:transfer:transfer-store-cosmos
+        run: ./gradlew clean check -x :extensions:catalog:catalog-atlas:check -x :extensions:security:security-azure:check  -x :extensions:transfer:transfer-nifi:check -x :external:nifi:processors:check -x extensions:transfer:transfer-store-cosmos:check
 
       - name: Publish Unit Test Results
         id: publish-results
@@ -98,4 +98,4 @@ jobs:
         id: cosmos-transferprocessstore-test
         env:
           COSMOS_KEY: ${{ secrets.COSMOS_DB_MASTERKEY }}
-        run: ./gradlew extensions:transfer:transfer-store-cosmos
+        run: ./gradlew extensions:transfer:transfer-store-cosmos:check

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -22,7 +22,7 @@ jobs:
           NIFI_API_AUTH: ${{ secrets.NIFI_API_AUTH }}
           S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
           S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
-        run: ./gradlew clean check -x :extensions:catalog:catalog-atlas:check -x :extensions:security:security-azure:check  -x :extensions:transfer:transfer-nifi:check -x :external:nifi:processors:check
+        run: ./gradlew clean check -x :extensions:catalog:catalog-atlas:check -x :extensions:security:security-azure:check  -x :extensions:transfer:transfer-nifi:check -x :external:nifi:processors:check -x extensions:transfer:transfer-store-cosmos
 
       - name: Publish Unit Test Results
         id: publish-results
@@ -93,3 +93,9 @@ jobs:
         env:
           AZ_STORAGE_SAS: ${{ secrets.AZ_STORAGE_SAS }}
         run: ./gradlew extensions:security:security-azure:check
+
+      - name: Test CosmosTransferProcessStore
+        id: cosmos-transferprocessstore-test
+        env:
+          COSMOS_KEY: ${{ secrets.COSMOS_DB_MASTERKEY }}
+        run: ./gradlew extensions:transfer:transfer-store-cosmos

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ distributions/azure/azure.properties
 **/secrets
 kubeconfig
 **/dagx-config.properties
+
+scripts/terraform.tfvars

--- a/distributions/demo-e2e/Dockerfile
+++ b/distributions/demo-e2e/Dockerfile
@@ -15,6 +15,6 @@ ENTRYPOINT java \
     -Ddagx.atlas.url=${ATLAS_URL} \
     -Ddagx.nifi.url=${NIFI_URL} \
     -Ddagx.nifi.flow.url=${NIFI_FLOW_URL} \
-    -Ddagx.cosmos.account.name=${COSMOS_ACCOUNT}
-    -Ddagx.cosmos.database.name=${COSMOS_DB}
+    -Ddagx.cosmos.account.name=${COSMOS_ACCOUNT} \
+    -Ddagx.cosmos.database.name=${COSMOS_DB} \
     -Djava.security.edg=file:/dev/.urandom -jar dagx-demo-e2e.jar

--- a/distributions/demo-e2e/Dockerfile
+++ b/distributions/demo-e2e/Dockerfile
@@ -15,4 +15,6 @@ ENTRYPOINT java \
     -Ddagx.atlas.url=${ATLAS_URL} \
     -Ddagx.nifi.url=${NIFI_URL} \
     -Ddagx.nifi.flow.url=${NIFI_FLOW_URL} \
+    -Ddagx.cosmos.account.name=${COSMOS_ACCOUNT}
+    -Ddagx.cosmos.database.name=${COSMOS_DB}
     -Djava.security.edg=file:/dev/.urandom -jar dagx-demo-e2e.jar

--- a/distributions/demo-e2e/build.gradle.kts
+++ b/distributions/demo-e2e/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
 
     // todo: replace with atlas - but we need this for the time being to provide catalog entries
     implementation(project(":extensions:catalog:catalog-atlas"))
-    implementation(project(":extensions:dataseed:dataseed-policy"))
+    implementation(project(":extensions:dataseed"))
 
     implementation(project(":extensions:security:security-azure"))
     implementation(project(":extensions:policy:policy-registry-memory"))

--- a/distributions/demo-e2e/build.gradle.kts
+++ b/distributions/demo-e2e/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
 
     // todo: replace with atlas - but we need this for the time being to provide catalog entries
     implementation(project(":extensions:catalog:catalog-atlas"))
-    implementation(project(":extensions:dataseed"))
+    implementation(project(":extensions:dataseed:dataseed-policy"))
 
     implementation(project(":extensions:security:security-azure"))
     implementation(project(":extensions:policy:policy-registry-memory"))

--- a/distributions/demo-e2e/build.gradle.kts
+++ b/distributions/demo-e2e/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     implementation(project(":extensions:control-http"))
 
     implementation(project(":extensions:transfer:transfer-core"))
-    implementation(project(":extensions:transfer:transfer-store-memory"))
+    implementation(project(":extensions:transfer:transfer-store-cosmos"))
     implementation(project(":extensions:transfer:transfer-provision-aws"))
     implementation(project(":extensions:transfer:transfer-provision-azure"))
     implementation(project(":extensions:transfer:transfer-nifi"))

--- a/extensions/catalog/catalog-atlas/src/main/java/com/microsoft/dagx/catalog/atlas/metadata/AtlasDataCatalogEntry.java
+++ b/extensions/catalog/catalog-atlas/src/main/java/com/microsoft/dagx/catalog/atlas/metadata/AtlasDataCatalogEntry.java
@@ -5,14 +5,18 @@
 
 package com.microsoft.dagx.catalog.atlas.metadata;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.microsoft.dagx.spi.types.domain.metadata.DataCatalogEntry;
 import com.microsoft.dagx.spi.types.domain.transfer.DataAddress;
 
+@JsonTypeName("dagx:atlascatalogentry")
 public class AtlasDataCatalogEntry implements DataCatalogEntry {
 
+    @JsonProperty
     private final DataAddress address;
 
-    public AtlasDataCatalogEntry(DataAddress address) {
+    public AtlasDataCatalogEntry(@JsonProperty("address") DataAddress address) {
 
         this.address = address;
     }

--- a/extensions/catalog/catalog-atlas/src/main/java/com/microsoft/dagx/catalog/atlas/metadata/AtlasExtension.java
+++ b/extensions/catalog/catalog-atlas/src/main/java/com/microsoft/dagx/catalog/atlas/metadata/AtlasExtension.java
@@ -49,6 +49,8 @@ public class AtlasExtension implements ServiceExtension {
         context.registerService(AtlasApi.class, api);
         context.registerService(MetadataStore.class, new AtlasMetadataStore(api, context.getMonitor(), context.getService(SchemaRegistry.class)));
         context.getMonitor().info("Initialized Atlas API extension.");
+
+        context.getTypeManager().registerTypes(AtlasDataCatalogEntry.class);
     }
 
 

--- a/extensions/catalog/catalog-atlas/src/main/java/com/microsoft/dagx/catalog/atlas/metadata/AtlasMetadataStore.java
+++ b/extensions/catalog/catalog-atlas/src/main/java/com/microsoft/dagx/catalog/atlas/metadata/AtlasMetadataStore.java
@@ -45,7 +45,7 @@ public class AtlasMetadataStore implements MetadataStore {
     }
 
     @Override
-    public @Nullable DataEntry<?> findForId(String id) {
+    public @Nullable DataEntry findForId(String id) {
 
         var properties = atlasApi.getEntityById(id);
 
@@ -100,12 +100,12 @@ public class AtlasMetadataStore implements MetadataStore {
     }
 
     @Override
-    public void save(DataEntry<?> entry) {
+    public void save(DataEntry entry) {
         monitor.severe("Save not yet implemented");
     }
 
     @Override
-    public @NotNull Collection<DataEntry<?>> queryAll(Collection<Policy> policies) {
+    public @NotNull Collection<DataEntry> queryAll(Collection<Policy> policies) {
         if (policies.isEmpty()) {
             return Collections.emptyList();
         }

--- a/extensions/catalog/catalog-atlas/src/test/java/com/microsoft/dagx/catalog/atlas/metadata/AtlasMetadataStoreTest.java
+++ b/extensions/catalog/catalog-atlas/src/test/java/com/microsoft/dagx/catalog/atlas/metadata/AtlasMetadataStoreTest.java
@@ -174,7 +174,7 @@ class AtlasMetadataStoreTest {
         replay(atlasApiMock);
         replay(monitorMock);
 
-        final Collection<DataEntry<?>> entries = atlasMetadataStore.queryAll(Collections.singleton(policy));
+        final Collection<DataEntry> entries = atlasMetadataStore.queryAll(Collections.singleton(policy));
         assertThat(entries).isNotNull().isNotEmpty().doesNotContainNull();
 
         assertThat(entries).allSatisfy(this::assertAzureEntry);
@@ -232,7 +232,7 @@ class AtlasMetadataStoreTest {
                 "region", "neverland"));
     }
 
-    private void assertAzureEntry(DataEntry<?> entry) {
+    private void assertAzureEntry(DataEntry entry) {
         assertThat(entry.getCatalogEntry().getAddress().getProperties()).isNotNull()
                 .hasFieldOrPropertyWithValue("keyName", KEY_NAME)
                 .hasFieldOrPropertyWithValue("type", AzureBlobStoreSchema.TYPE)

--- a/extensions/demo/demo-nifi/src/main/java/com/microsoft/dagx/demo/nifi/NifiDemoServiceExtension.java
+++ b/extensions/demo/demo-nifi/src/main/java/com/microsoft/dagx/demo/nifi/NifiDemoServiceExtension.java
@@ -12,7 +12,6 @@ import com.microsoft.dagx.spi.monitor.Monitor;
 import com.microsoft.dagx.spi.policy.PolicyRegistry;
 import com.microsoft.dagx.spi.system.ServiceExtension;
 import com.microsoft.dagx.spi.system.ServiceExtensionContext;
-import com.microsoft.dagx.spi.types.domain.metadata.DataCatalogEntry;
 import com.microsoft.dagx.spi.types.domain.metadata.DataEntry;
 import com.microsoft.dagx.spi.types.domain.metadata.GenericDataCatalogEntry;
 
@@ -60,10 +59,10 @@ public class NifiDemoServiceExtension implements ServiceExtension {
                 .property("type", AzureBlobStoreSchema.TYPE)
                 .build();
 
-        DataEntry<DataCatalogEntry> entry1 = DataEntry.Builder.newInstance().id("test123").policyId(USE_EU_POLICY).catalogEntry(sourceFileCatalog).build();
+        DataEntry entry1 = DataEntry.Builder.newInstance().id("test123").policyId(USE_EU_POLICY).catalogEntry(sourceFileCatalog).build();
         metadataStore.save(entry1);
 
-        DataEntry<DataCatalogEntry> entry2 = DataEntry.Builder.newInstance().id("test456").policyId(USE_US_OR_EU_POLICY).catalogEntry(sourceFileCatalog).build();
+        DataEntry entry2 = DataEntry.Builder.newInstance().id("test456").policyId(USE_US_OR_EU_POLICY).catalogEntry(sourceFileCatalog).build();
         metadataStore.save(entry2);
     }
 

--- a/extensions/demo/demo-ui-api/src/main/java/com/microsoft/dagx/demo/ui/DemoUiApiController.java
+++ b/extensions/demo/demo-ui-api/src/main/java/com/microsoft/dagx/demo/ui/DemoUiApiController.java
@@ -78,7 +78,7 @@ public class DemoUiApiController {
 
     }
 
-    private DataRequest createRequest(String connector, String id, DataEntry<?> artifactId) {
+    private DataRequest createRequest(String connector, String id, DataEntry artifactId) {
         return DataRequest.Builder.newInstance()
                 .id(id)
                 .protocol("ids-rest")

--- a/extensions/ids/ids-api-catalog/src/main/java/com/microsoft/dagx/ids/api/catalog/QueryEngine.java
+++ b/extensions/ids/ids-api-catalog/src/main/java/com/microsoft/dagx/ids/api/catalog/QueryEngine.java
@@ -13,6 +13,6 @@ public interface QueryEngine {
     /**
      * Executes a query. Implementations must treat the query as originating from an untrusted source.
      */
-    Collection<DataEntry<?>> execute(String correlationId, ClaimToken clientToken, String connectorId, String type, String query);
+    Collection<DataEntry> execute(String correlationId, ClaimToken clientToken, String connectorId, String type, String query);
 
 }

--- a/extensions/ids/ids-api-catalog/src/main/java/com/microsoft/dagx/ids/api/catalog/QueryEngineImpl.java
+++ b/extensions/ids/ids-api-catalog/src/main/java/com/microsoft/dagx/ids/api/catalog/QueryEngineImpl.java
@@ -16,10 +16,10 @@ import static java.util.stream.Collectors.toList;
  *
  */
 public class QueryEngineImpl implements QueryEngine {
-    private PolicyRegistry policyRegistry;
-    private IdsPolicyService policyService;
-    private MetadataStore metadataStore;
-    private Monitor monitor;
+    private final PolicyRegistry policyRegistry;
+    private final IdsPolicyService policyService;
+    private final MetadataStore metadataStore;
+    private final Monitor monitor;
 
     public QueryEngineImpl(PolicyRegistry policyRegistry, IdsPolicyService policyService, MetadataStore metadataStore, Monitor monitor) {
         this.policyRegistry = policyRegistry;
@@ -29,7 +29,7 @@ public class QueryEngineImpl implements QueryEngine {
     }
 
     @Override
-    public Collection<DataEntry<?>> execute(String correlationId, ClaimToken clientToken, String connectorId, String type, String query) {
+    public Collection<DataEntry> execute(String correlationId, ClaimToken clientToken, String connectorId, String type, String query) {
         if (!"select *".equalsIgnoreCase(query)) {
             monitor.info("Invalid query: " + query);
             return Collections.emptyList();

--- a/extensions/metadata/metadata-memory/src/main/java/com/microsoft/dagx/metadata/memory/InMemoryMetadataStore.java
+++ b/extensions/metadata/metadata-memory/src/main/java/com/microsoft/dagx/metadata/memory/InMemoryMetadataStore.java
@@ -24,20 +24,20 @@ import static java.util.stream.Collectors.toSet;
  * An ephemeral metadata store.
  */
 public class InMemoryMetadataStore implements MetadataStore {
-    private Map<String, DataEntry<?>> cache = new ConcurrentHashMap<>();
+    private final Map<String, DataEntry> cache = new ConcurrentHashMap<>();
 
     @Override
-    public @Nullable DataEntry<?> findForId(String id) {
+    public @Nullable DataEntry findForId(String id) {
         return cache.get(id);
     }
 
     @Override
-    public void save(DataEntry<?> entry) {
+    public void save(DataEntry entry) {
         cache.put(entry.getId(), entry);
     }
 
     @Override
-    public @NotNull Collection<DataEntry<?>> queryAll(Collection<Policy> policies) {
+    public @NotNull Collection<DataEntry> queryAll(Collection<Policy> policies) {
         Set<String> policyIds = policies.stream().map(Identifiable::getUid).collect(toSet());
         return cache.values().stream().filter(entry -> policyIds.contains(entry.getPolicyId())).collect(Collectors.toList());
     }

--- a/extensions/security/security-azure/src/main/java/com/microsoft/dagx/security/azure/AzureVault.java
+++ b/extensions/security/security-azure/src/main/java/com/microsoft/dagx/security/azure/AzureVault.java
@@ -65,7 +65,6 @@ public class AzureVault implements Vault {
 
             key = sanitizeKey(key);
             var secret = secretClient.getSecret(key);
-//            monitor.debug("Secret obtained successfully");
             return secret.getValue();
         } catch (ResourceNotFoundException ex) {
             monitor.severe("Secret not found!", ex);

--- a/extensions/security/security-azure/src/main/java/com/microsoft/dagx/security/azure/AzureVault.java
+++ b/extensions/security/security-azure/src/main/java/com/microsoft/dagx/security/azure/AzureVault.java
@@ -65,7 +65,7 @@ public class AzureVault implements Vault {
 
             key = sanitizeKey(key);
             var secret = secretClient.getSecret(key);
-            monitor.debug("Secret obtained successfully");
+//            monitor.debug("Secret obtained successfully");
             return secret.getValue();
         } catch (ResourceNotFoundException ex) {
             monitor.severe("Secret not found!", ex);

--- a/extensions/transfer/transfer-nifi/src/main/java/com/microsoft/dagx/transfer/nifi/NifiDataFlowController.java
+++ b/extensions/transfer/transfer-nifi/src/main/java/com/microsoft/dagx/transfer/nifi/NifiDataFlowController.java
@@ -73,7 +73,7 @@ public class NifiDataFlowController implements DataFlowController {
             return new DataFlowInitiateResponse(FATAL_ERROR, "NiFi vault credentials were not found");
         }
 
-        DataEntry<?> dataEntry = dataRequest.getDataEntry();
+        DataEntry dataEntry = dataRequest.getDataEntry();
         DataCatalogEntry catalog = dataEntry.getCatalogEntry();
         var sourceAddress = catalog.getAddress();
         // the "keyName" entry should always be there, regardless of the source storage system

--- a/extensions/transfer/transfer-nifi/src/main/java/com/microsoft/dagx/transfer/nifi/NifiTransferEndpointConverter.java
+++ b/extensions/transfer/transfer-nifi/src/main/java/com/microsoft/dagx/transfer/nifi/NifiTransferEndpointConverter.java
@@ -13,6 +13,7 @@ import com.microsoft.dagx.spi.security.Vault;
 import com.microsoft.dagx.spi.types.TypeManager;
 import com.microsoft.dagx.spi.types.domain.transfer.DataAddress;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -44,11 +45,11 @@ public class NifiTransferEndpointConverter {
         validate(dataAddress, schema);
 
 
-        var keyName = dataAddress.getProperties().remove("keyName");
-        dataAddress.getProperties().remove("type");
+        var keyName = dataAddress.getProperties().get("keyName");
 
+        //need to duplicate the properties here, otherwise the secret would potentially be stored together with the TransferProcess 
+        Map<String, String> properties = new HashMap<>(dataAddress.getProperties());
 
-        Map<String, String> properties = dataAddress.getProperties();
         String secret = vault.resolveSecret(keyName);
 
         //different endpoints might have different credentials, such as SAS token, access key id + secret, etc.

--- a/extensions/transfer/transfer-nifi/src/main/java/com/microsoft/dagx/transfer/nifi/NifiTransferEndpointConverter.java
+++ b/extensions/transfer/transfer-nifi/src/main/java/com/microsoft/dagx/transfer/nifi/NifiTransferEndpointConverter.java
@@ -47,7 +47,7 @@ public class NifiTransferEndpointConverter {
 
         var keyName = dataAddress.getProperties().get("keyName");
 
-        //need to duplicate the properties here, otherwise the secret would potentially be stored together with the TransferProcess 
+        //need to duplicate the properties here, otherwise the secret would potentially be stored together with the TransferProcess
         Map<String, String> properties = new HashMap<>(dataAddress.getProperties());
 
         String secret = vault.resolveSecret(keyName);

--- a/extensions/transfer/transfer-nifi/src/test/java/com/microsoft/dagx/transfer/nifi/NifiDataFlowControllerTest.java
+++ b/extensions/transfer/transfer-nifi/src/test/java/com/microsoft/dagx/transfer/nifi/NifiDataFlowControllerTest.java
@@ -25,7 +25,6 @@ import com.microsoft.dagx.spi.security.Vault;
 import com.microsoft.dagx.spi.transfer.flow.DataFlowInitiateResponse;
 import com.microsoft.dagx.spi.transfer.response.ResponseStatus;
 import com.microsoft.dagx.spi.types.TypeManager;
-import com.microsoft.dagx.spi.types.domain.metadata.DataCatalogEntry;
 import com.microsoft.dagx.spi.types.domain.metadata.DataEntry;
 import com.microsoft.dagx.spi.types.domain.metadata.GenericDataCatalogEntry;
 import com.microsoft.dagx.spi.types.domain.transfer.DataAddress;
@@ -306,7 +305,7 @@ public class NifiDataFlowControllerTest {
                 .property("container", containerName)
                 .property("account", storageAccount)
                 .build());
-        DataEntry<DataCatalogEntry> entry = DataEntry.Builder.newInstance().id(id).catalogEntry(lookup).build();
+        DataEntry entry = DataEntry.Builder.newInstance().id(id).catalogEntry(lookup).build();
 
         // connect the "source" (i.e. the lookup) and the "destination"
         DataRequest dataRequest = DataRequest.Builder.newInstance()
@@ -341,7 +340,7 @@ public class NifiDataFlowControllerTest {
     void initiateFlow_withInMemCatalog() throws InterruptedException {
 
         String id = UUID.randomUUID().toString();
-        DataEntry<DataCatalogEntry> entry = DataEntry.Builder.newInstance().id(id).catalogEntry(createAzureCatalogEntry()).build();
+        DataEntry entry = DataEntry.Builder.newInstance().id(id).catalogEntry(createAzureCatalogEntry()).build();
 
         DataRequest dataRequest = DataRequest.Builder.newInstance()
                 .id(id)
@@ -376,7 +375,7 @@ public class NifiDataFlowControllerTest {
         String id = UUID.randomUUID().toString();
         GenericDataCatalogEntry lookup = createAzureCatalogEntry();
         lookup.getProperties().replace("blobname", "notexist.png");
-        DataEntry<DataCatalogEntry> entry = DataEntry.Builder.newInstance()
+        DataEntry entry = DataEntry.Builder.newInstance()
                 .id(id)
                 .catalogEntry(lookup)
                 .build();
@@ -405,7 +404,7 @@ public class NifiDataFlowControllerTest {
     @DisplayName("Don't transfer if no creds are found in vault")
     void initiateFlow_noCredsFoundInVault() {
         String id = UUID.randomUUID().toString();
-        DataEntry<DataCatalogEntry> entry = DataEntry.Builder.newInstance().catalogEntry(createAzureCatalogEntry()).build();
+        DataEntry entry = DataEntry.Builder.newInstance().catalogEntry(createAzureCatalogEntry()).build();
 
         DataRequest dataRequest = DataRequest.Builder.newInstance()
                 .id(id)
@@ -428,7 +427,7 @@ public class NifiDataFlowControllerTest {
     @DisplayName("transfer from Azure Blob to S3")
     void transfer_fromAzureBlob_toS3() throws InterruptedException {
         String id = UUID.randomUUID().toString();
-        DataEntry<DataCatalogEntry> entry = DataEntry.Builder.newInstance().id(id).catalogEntry(createAzureCatalogEntry()).build();
+        DataEntry entry = DataEntry.Builder.newInstance().id(id).catalogEntry(createAzureCatalogEntry()).build();
 
         DataRequest dataRequest = DataRequest.Builder.newInstance()
                 .id(id)
@@ -462,7 +461,7 @@ public class NifiDataFlowControllerTest {
     @DisplayName("transfer from S3 to Azure Blob")
     void transfer_fromS3_toAzureBlob() throws InterruptedException {
         String id = UUID.randomUUID().toString();
-        DataEntry<DataCatalogEntry> entry = DataEntry.Builder.newInstance().id(id).catalogEntry(createS3CatalogEntry()).build();
+        DataEntry entry = DataEntry.Builder.newInstance().id(id).catalogEntry(createS3CatalogEntry()).build();
 
         DataRequest dataRequest = DataRequest.Builder.newInstance()
                 .id(id)
@@ -496,7 +495,7 @@ public class NifiDataFlowControllerTest {
     @DisplayName("transfer from S3 to S3")
     void transfer_fromS3_toS3() throws InterruptedException {
         String id = UUID.randomUUID().toString();
-        DataEntry<DataCatalogEntry> entry = DataEntry.Builder.newInstance().id(id).catalogEntry(createS3CatalogEntry()).build();
+        DataEntry entry = DataEntry.Builder.newInstance().id(id).catalogEntry(createS3CatalogEntry()).build();
 
         DataRequest dataRequest = DataRequest.Builder.newInstance()
                 .id(id)
@@ -529,7 +528,7 @@ public class NifiDataFlowControllerTest {
     @DisplayName("transfer from Azure Blob to Azure blob")
     void transfer_fromAzureBlob_toAzureBlob() throws InterruptedException {
         String id = UUID.randomUUID().toString();
-        DataEntry<DataCatalogEntry> entry = DataEntry.Builder.newInstance().id(id).catalogEntry(createAzureCatalogEntry()).build();
+        DataEntry entry = DataEntry.Builder.newInstance().id(id).catalogEntry(createAzureCatalogEntry()).build();
 
         DataRequest dataRequest = DataRequest.Builder.newInstance()
                 .id(id)
@@ -571,7 +570,7 @@ public class NifiDataFlowControllerTest {
 
 
         dataEntry.getProperties().replace("blobname", "[\"" + blobName + "\", \"" + secondBlobName + "\"]");
-        DataEntry<DataCatalogEntry> entry = DataEntry.Builder.newInstance()
+        DataEntry entry = DataEntry.Builder.newInstance()
                 .id(id)
                 .catalogEntry(dataEntry)
                 .build();
@@ -612,7 +611,7 @@ public class NifiDataFlowControllerTest {
 
         dataEntry.getProperties().replace("blobname", "[\"" + blobName + "\", \"" + secondBlobName + "\"]");
 
-        DataEntry<DataCatalogEntry> entry = DataEntry.Builder.newInstance()
+        DataEntry entry = DataEntry.Builder.newInstance()
                 .id(id)
                 .catalogEntry(dataEntry)
                 .build();
@@ -655,7 +654,7 @@ public class NifiDataFlowControllerTest {
 
 
         dataEntry.getProperties().remove("blobname");
-        DataEntry<DataCatalogEntry> entry = DataEntry.Builder.newInstance()
+        DataEntry entry = DataEntry.Builder.newInstance()
                 .id(id)
                 .catalogEntry(dataEntry)
                 .build();
@@ -699,7 +698,7 @@ public class NifiDataFlowControllerTest {
 
 
         dataEntry.getProperties().remove("blobname");
-        DataEntry<DataCatalogEntry> entry = DataEntry.Builder.newInstance()
+        DataEntry entry = DataEntry.Builder.newInstance()
                 .id(id)
                 .catalogEntry(dataEntry)
                 .build();

--- a/extensions/transfer/transfer-store-cosmos/build.gradle.kts
+++ b/extensions/transfer/transfer-store-cosmos/build.gradle.kts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * All rights reserved.
+ */
+
+plugins {
+    `java-library`
+}
+
+val cosmosSdkVersion: String by project;
+
+dependencies {
+    api(project(":spi"))
+    api(project(":common"))
+
+    implementation("com.azure:azure-cosmos:${cosmosSdkVersion}")
+}
+
+

--- a/extensions/transfer/transfer-store-cosmos/build.gradle.kts
+++ b/extensions/transfer/transfer-store-cosmos/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     `java-library`
 }
 
-val cosmosSdkVersion: String by project;
+val cosmosSdkVersion: String by project
 
 dependencies {
     api(project(":spi"))

--- a/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStore.java
+++ b/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStore.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *  All rights reserved.
+ *
+ */
+
+package com.microsoft.dagx.transfer.store.cosmos;
+
+import com.azure.cosmos.CosmosClient;
+import com.azure.cosmos.CosmosContainer;
+import com.azure.cosmos.CosmosDatabase;
+import com.azure.cosmos.models.CosmosDatabaseResponse;
+import com.azure.cosmos.models.CosmosQueryRequestOptions;
+import com.azure.cosmos.models.PartitionKey;
+import com.microsoft.dagx.spi.transfer.store.TransferProcessStore;
+import com.microsoft.dagx.spi.types.domain.transfer.TransferProcess;
+import com.microsoft.dagx.transfer.store.cosmos.model.TransferProcessDocument;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Set;
+
+public class CosmosTransferProcessStore implements TransferProcessStore {
+
+
+    private final String containerName;
+    private final CosmosContainer container;
+
+    public CosmosTransferProcessStore(CosmosClient client, String cosmosDbName, String containerName) {
+        this.containerName = containerName;
+        var database = validateCosmos(client, cosmosDbName);
+        container = database.getContainer(containerName);
+    }
+
+    @Override
+    public TransferProcess find(String id) {
+        CosmosQueryRequestOptions queryOptions = new CosmosQueryRequestOptions();
+        //  Set populate query metrics to get metrics around query executions
+        queryOptions.setQueryMetricsEnabled(true);
+
+        container.readItem(id, new PartitionKey(id), TransferProcessDocument.class);
+
+        return null;
+    }
+
+    @Override
+    public @Nullable String processIdForTransferId(String id) {
+        return null;
+    }
+
+    @Override
+    public @NotNull List<TransferProcess> nextForState(int state, int max) {
+        return null;
+    }
+
+    @Override
+    public void create(TransferProcess process) {
+
+    }
+
+    @Override
+    public void update(TransferProcess process) {
+
+    }
+
+    @Override
+    public void delete(String processId) {
+
+    }
+
+    @Override
+    public void createData(String processId, String key, Object data) {
+
+    }
+
+    @Override
+    public void updateData(String processId, String key, Object data) {
+
+    }
+
+    @Override
+    public void deleteData(String processId, String key) {
+
+    }
+
+    @Override
+    public void deleteData(String processId, Set<String> keys) {
+
+    }
+
+    @Override
+    public <T> T findData(Class<T> type, String processId, String resourceDefinitionId) {
+        return null;
+    }
+
+    private CosmosDatabase validateCosmos(CosmosClient client, String databaseName) {
+        CosmosDatabaseResponse databaseResponse = client.createDatabaseIfNotExists(databaseName);
+        return client.getDatabase(databaseResponse.getProperties().getId());
+    }
+}

--- a/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStore.java
+++ b/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStore.java
@@ -94,6 +94,7 @@ public class CosmosTransferProcessStore implements TransferProcessStore {
 
     }
 
+    //todo: use real connector id
     private String getConnectorId() {
         return "dagx-connector";
     }

--- a/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStore.java
+++ b/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStore.java
@@ -6,12 +6,14 @@
 
 package com.microsoft.dagx.transfer.store.cosmos;
 
-import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosContainer;
-import com.azure.cosmos.CosmosDatabase;
-import com.azure.cosmos.models.CosmosDatabaseResponse;
+import com.azure.cosmos.CosmosException;
+import com.azure.cosmos.models.CosmosItemRequestOptions;
+import com.azure.cosmos.models.CosmosItemResponse;
 import com.azure.cosmos.models.CosmosQueryRequestOptions;
 import com.azure.cosmos.models.PartitionKey;
+import com.azure.cosmos.util.CosmosPagedIterable;
+import com.microsoft.dagx.spi.DagxException;
 import com.microsoft.dagx.spi.transfer.store.TransferProcessStore;
 import com.microsoft.dagx.spi.types.domain.transfer.TransferProcess;
 import com.microsoft.dagx.transfer.store.cosmos.model.TransferProcessDocument;
@@ -19,29 +21,28 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class CosmosTransferProcessStore implements TransferProcessStore {
 
 
-    private final String containerName;
     private final CosmosContainer container;
 
-    public CosmosTransferProcessStore(CosmosClient client, String cosmosDbName, String containerName) {
-        this.containerName = containerName;
-        var database = validateCosmos(client, cosmosDbName);
-        container = database.getContainer(containerName);
+    public CosmosTransferProcessStore(CosmosContainer container) {
+
+        this.container = container;
     }
 
     @Override
     public TransferProcess find(String id) {
-        CosmosQueryRequestOptions queryOptions = new CosmosQueryRequestOptions();
-        //  Set populate query metrics to get metrics around query executions
-        queryOptions.setQueryMetricsEnabled(true);
+        CosmosItemRequestOptions options = new CosmosItemRequestOptions();
+        final CosmosItemResponse<TransferProcessDocument> response = container.readItem(id, new PartitionKey(id), options, TransferProcessDocument.class);
 
-        container.readItem(id, new PartitionKey(id), TransferProcessDocument.class);
+        var process = response.getItem();
 
-        return null;
+        return process.getWrappedInstance();
     }
 
     @Override
@@ -51,51 +52,88 @@ public class CosmosTransferProcessStore implements TransferProcessStore {
 
     @Override
     public @NotNull List<TransferProcess> nextForState(int state, int max) {
-        return null;
+        //todo: lock rows for update
+
+        CosmosQueryRequestOptions options = new CosmosQueryRequestOptions();
+        options.setQueryMetricsEnabled(true);
+        options.setMaxBufferedItemCount(max);
+
+        var query = "SELECT * FROM TransferProcessDocument WHERE TransferProcessDocument.state = " + state + " ORDER BY TransferProcessDocument.stateTimestamp OFFSET 0 LIMIT " + max;
+
+        final CosmosPagedIterable<TransferProcessDocument> processes = container.queryItems(query, options, TransferProcessDocument.class);
+
+        return processes.stream().map(TransferProcessDocument::getWrappedInstance).collect(Collectors.toList());
     }
 
     @Override
     public void create(TransferProcess process) {
 
+        Objects.requireNonNull(process.getId(), "TransferProcesses must have an ID!");
+
+        CosmosItemRequestOptions options = new CosmosItemRequestOptions();
+        //todo: configure indexing
+        var document = TransferProcessDocument.from(process);
+        try {
+            final var response = container.createItem(document, new PartitionKey(process.getId()), options);
+            handleResponse(response);
+        } catch (CosmosException cme) {
+            throw new DagxException(cme);
+        }
     }
+
 
     @Override
     public void update(TransferProcess process) {
-
+        var document = TransferProcessDocument.from(process);
+        try {
+            final var response = container.upsertItem(document, new PartitionKey(process.getId()), new CosmosItemRequestOptions());
+            handleResponse(response);
+        } catch (CosmosException cme) {
+            throw new DagxException(cme);
+        }
     }
 
     @Override
     public void delete(String processId) {
+        try {
+            var response = container.deleteItem(processId, new PartitionKey(processId), new CosmosItemRequestOptions());
+            handleResponse(response);
+        } catch (CosmosException cme) {
+            throw new DagxException(cme);
+        }
 
     }
 
     @Override
     public void createData(String processId, String key, Object data) {
-
+        throw new UnsupportedOperationException("Not yet implemented");
     }
 
     @Override
     public void updateData(String processId, String key, Object data) {
-
+        throw new UnsupportedOperationException("Not yet implemented");
     }
 
     @Override
     public void deleteData(String processId, String key) {
-
+        throw new UnsupportedOperationException("Not yet implemented");
     }
 
     @Override
     public void deleteData(String processId, Set<String> keys) {
-
+        throw new UnsupportedOperationException("Not yet implemented");
     }
 
     @Override
     public <T> T findData(Class<T> type, String processId, String resourceDefinitionId) {
-        return null;
+        throw new UnsupportedOperationException("Not yet implemented");
     }
 
-    private CosmosDatabase validateCosmos(CosmosClient client, String databaseName) {
-        CosmosDatabaseResponse databaseResponse = client.createDatabaseIfNotExists(databaseName);
-        return client.getDatabase(databaseResponse.getProperties().getId());
+
+    private void handleResponse(CosmosItemResponse<?> response) {
+        final int code = response.getStatusCode();
+        if (code < 200 || code >= 300) {
+            throw new DagxException("Error creating TransferProcess in CosmosDB: " + code);
+        }
     }
 }

--- a/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStore.java
+++ b/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStore.java
@@ -144,8 +144,6 @@ public class CosmosTransferProcessStore implements TransferProcessStore {
             //noop
         } catch (CosmosException cme) {
             throw new DagxException(cme);
-        } finally {
-            releaseLease(processId);
         }
 
     }
@@ -175,17 +173,6 @@ public class CosmosTransferProcessStore implements TransferProcessStore {
         throw new UnsupportedOperationException("Not yet implemented");
     }
 
-    @Override
-    public void lock(TransferProcess process) {
-        final String transferProcessId = process.getId();
-//        acquireLease(transferProcessId);
-    }
-
-    @Override
-    public void unlock(TransferProcess process) {
-//        releaseLease(process.getId());
-    }
-
     private void handleResponse(CosmosItemResponse<?> response) {
         final int code = response.getStatusCode();
         if (code < 200 || code >= 300) {
@@ -197,12 +184,5 @@ public class CosmosTransferProcessStore implements TransferProcessStore {
         return typeManager.readValue(typeManager.writeValueAsBytes(databaseDocument), TransferProcessDocument.class);
     }
 
-    private void acquireLease(String transferProcessId) {
-//        blobStoreApi.acquireLease(leaseConfiguration.getAccountName(), leaseConfiguration.getContainerName(), transferProcessId, transferProcessId, -1);
-    }
-
-    private void releaseLease(String transferProcessId) {
-//        blobStoreApi.releaseLease(leaseConfiguration.getAccountName(), leaseConfiguration.getContainerName(), transferProcessId, transferProcessId);
-    }
 
 }

--- a/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreExtension.java
+++ b/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreExtension.java
@@ -19,6 +19,7 @@ import com.microsoft.dagx.spi.security.Vault;
 import com.microsoft.dagx.spi.system.ServiceExtension;
 import com.microsoft.dagx.spi.system.ServiceExtensionContext;
 import com.microsoft.dagx.spi.transfer.store.TransferProcessStore;
+import com.microsoft.dagx.transfer.store.cosmos.model.TransferProcessDocument;
 
 import java.util.ArrayList;
 
@@ -32,6 +33,9 @@ public class CosmosTransferProcessStoreExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
+
+        monitor = context.getMonitor();
+        monitor.info("Initializing Cosmos Memory Transfer Process Store extension...");
 
         var cosmosAccountName = context.getSetting(COSMOS_ACCOUNTNAME_SETTING, null);
         if (StringUtils.isNullOrEmpty(cosmosAccountName)) {
@@ -64,10 +68,11 @@ public class CosmosTransferProcessStoreExtension implements ServiceExtension {
         final CosmosContainerResponse response = database.createContainerIfNotExists("dagx-transferprocess", "/partitionKey");
         var container = database.getContainer(response.getProperties().getId());
 
-        context.registerService(TransferProcessStore.class, new CosmosTransferProcessStore(container));
+        context.registerService(TransferProcessStore.class, new CosmosTransferProcessStore(container, context.getTypeManager()));
 
-        monitor = context.getMonitor();
+        context.getTypeManager().registerTypes(TransferProcessDocument.class);
         monitor.info("Initialized Cosmos Memory Transfer Process Store extension");
+
     }
 
 

--- a/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreExtension.java
+++ b/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreExtension.java
@@ -88,7 +88,7 @@ public class CosmosTransferProcessStoreExtension implements ServiceExtension {
         context.registerService(TransferProcessStore.class, new CosmosTransferProcessStore(container, context.getTypeManager(), partitionKey));
 
         context.getTypeManager().registerTypes(TransferProcessDocument.class);
-        monitor.info("Initialized Cosmos Memory Transfer Process Store extension");
+        monitor.info("Initialized CosmosDB Transfer Process Store extension");
 
     }
 

--- a/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreExtension.java
+++ b/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreExtension.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *  All rights reserved.
+ *
+ */
+
+package com.microsoft.dagx.transfer.store.cosmos;
+
+import com.azure.core.credential.AzureKeyCredential;
+import com.azure.cosmos.ConsistencyLevel;
+import com.azure.cosmos.CosmosClientBuilder;
+import com.microsoft.dagx.common.string.StringUtils;
+import com.microsoft.dagx.spi.DagxException;
+import com.microsoft.dagx.spi.monitor.Monitor;
+import com.microsoft.dagx.spi.security.Vault;
+import com.microsoft.dagx.spi.system.ServiceExtension;
+import com.microsoft.dagx.spi.system.ServiceExtensionContext;
+import com.microsoft.dagx.spi.transfer.store.TransferProcessStore;
+
+import java.util.ArrayList;
+
+/**
+ * Provides an in-memory implementation of the {@link com.microsoft.dagx.spi.transfer.store.TransferProcessStore} for testing.
+ */
+public class CosmosTransferProcessStoreExtension implements ServiceExtension {
+    private final static String COSMOS_ACCOUNTNAME_SETTING = "dagx.cosmos.account.name";
+    private final static String COSMOS_DBNAME_SETTING = "dagx.cosmos.database.name";
+    private Monitor monitor;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+
+        var cosmosAccountName = context.getSetting(COSMOS_ACCOUNTNAME_SETTING, null);
+        if (StringUtils.isNullOrEmpty(cosmosAccountName)) {
+            throw new DagxException("'" + COSMOS_ACCOUNTNAME_SETTING + "' cannot be null or empty!");
+        }
+        var cosmosDbName = context.getSetting(COSMOS_DBNAME_SETTING, null);
+        if (StringUtils.isNullOrEmpty(cosmosDbName)) {
+            throw new DagxException("'" + COSMOS_DBNAME_SETTING + "' cannot be null or empty!");
+        }
+
+        var vault = context.getService(Vault.class);
+        var accountKey = vault.resolveSecret(cosmosAccountName);
+        if (StringUtils.isNullOrEmpty(accountKey)) {
+            throw new DagxException("No credentials found in vault for Cosmos DB '" + cosmosAccountName + "'");
+        }
+
+        final String host = "https://" + cosmosAccountName + ".documents.azure.com:443/";
+
+        ArrayList<String> preferredRegions = new ArrayList<>();
+        preferredRegions.add("West US");
+        var client = new CosmosClientBuilder()
+                .endpoint(host)
+                .credential(new AzureKeyCredential(accountKey))
+                .preferredRegions(preferredRegions)
+                .userAgentSuffix("CosmosDBJavaQuickstart")
+                .consistencyLevel(ConsistencyLevel.SESSION)
+                .buildClient();
+
+
+        context.registerService(TransferProcessStore.class, new CosmosTransferProcessStore(client, cosmosDbName, "dagx-transferprocess"));
+
+        monitor = context.getMonitor();
+        monitor.info("Initialized Cosmos Memory Transfer Process Store extension");
+    }
+
+
+    @Override
+    public void start() {
+        monitor.info("Started Initialized Cosmos Transfer Process Store extension");
+    }
+
+    @Override
+    public void shutdown() {
+        monitor.info("Shutdown Initialized Cosmos Transfer Process Store extension");
+    }
+
+}
+

--- a/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreExtension.java
+++ b/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreExtension.java
@@ -93,6 +93,7 @@ public class CosmosTransferProcessStoreExtension implements ServiceExtension {
         // get unique connector name
         var connectorId = context.getSetting("dagx.ids.connector.name", "dagx-connector-" + UUID.randomUUID());
 
+        monitor.info("CosmosTransferProcessStore will use connector id '" + connectorId + "'");
         context.registerService(TransferProcessStore.class, new CosmosTransferProcessStore(container, context.getTypeManager(), partitionKey, connectorId));
 
         context.getTypeManager().registerTypes(TransferProcessDocument.class);

--- a/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreExtension.java
+++ b/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreExtension.java
@@ -10,7 +10,6 @@ import com.azure.cosmos.ConsistencyLevel;
 import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.cosmos.CosmosDatabase;
-import com.azure.cosmos.models.CosmosContainerResponse;
 import com.azure.cosmos.models.CosmosDatabaseResponse;
 import com.microsoft.dagx.common.string.StringUtils;
 import com.microsoft.dagx.spi.DagxException;
@@ -22,13 +21,25 @@ import com.microsoft.dagx.spi.transfer.store.TransferProcessStore;
 import com.microsoft.dagx.transfer.store.cosmos.model.TransferProcessDocument;
 
 import java.util.ArrayList;
+import java.util.Set;
 
 /**
  * Provides an in-memory implementation of the {@link com.microsoft.dagx.spi.transfer.store.TransferProcessStore} for testing.
  */
 public class CosmosTransferProcessStoreExtension implements ServiceExtension {
+    /**
+     * The setting for the CosmosDB account name
+     */
     private final static String COSMOS_ACCOUNTNAME_SETTING = "dagx.cosmos.account.name";
+    /**
+     * The setting for the name of the database where TransferProcesses will be stored
+     */
     private final static String COSMOS_DBNAME_SETTING = "dagx.cosmos.database.name";
+
+    private final static String COSMOS_PARTITION_KEY_SETTING = "dagx.cosmos.partitionkey";
+    private final static String DEFAULT_PARTITION_KEY = "dagx";
+    private final static String CONTAINER_NAME = "dagx-transferprocess";
+
     private Monitor monitor;
 
     @Override
@@ -65,16 +76,26 @@ public class CosmosTransferProcessStoreExtension implements ServiceExtension {
 
 
         var database = getDatabase(client, cosmosDbName);
-        final CosmosContainerResponse response = database.createContainerIfNotExists("dagx-transferprocess", "/partitionKey");
-        var container = database.getContainer(response.getProperties().getId());
+        if (database.readAllContainers().stream().noneMatch(sp -> sp.getId().equals(CONTAINER_NAME))) {
+            throw new DagxException("A CosmosDB container named '" + CONTAINER_NAME + "' was not found in account '" + cosmosAccountName + "'. Please create one, preferably using terraform.");
+        }
 
-        context.registerService(TransferProcessStore.class, new CosmosTransferProcessStore(container, context.getTypeManager()));
+//        final CosmosContainerResponse response = database.createContainerIfNotExists(CONTAINER_NAME, "/partitionKey");
+//        var container = database.getContainer(response.getProperties().getId());
+
+        var container = database.getContainer(CONTAINER_NAME);
+        var partitionKey = context.getSetting(COSMOS_PARTITION_KEY_SETTING, DEFAULT_PARTITION_KEY);
+        context.registerService(TransferProcessStore.class, new CosmosTransferProcessStore(container, context.getTypeManager(), partitionKey));
 
         context.getTypeManager().registerTypes(TransferProcessDocument.class);
         monitor.info("Initialized Cosmos Memory Transfer Process Store extension");
 
     }
 
+    @Override
+    public Set<String> requires() {
+        return Set.of("dagx:blobstoreapi");
+    }
 
     @Override
     public void start() {
@@ -90,5 +111,7 @@ public class CosmosTransferProcessStoreExtension implements ServiceExtension {
         CosmosDatabaseResponse databaseResponse = client.createDatabaseIfNotExists(databaseName);
         return client.getDatabase(databaseResponse.getProperties().getId());
     }
+
+
 }
 

--- a/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/model/Lease.java
+++ b/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/model/Lease.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *  All rights reserved.
+ *
+ */
+
+package com.microsoft.dagx.transfer.store.cosmos.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+public class Lease {
+    @JsonProperty
+    private final String leasedBy;
+    @JsonProperty
+    private final long leasedAt;
+    @JsonProperty
+    private final long leasedUntil;
+
+    Lease(String leasedBy) {
+        this(leasedBy, Instant.now().toEpochMilli(), Instant.now().plus(60, ChronoUnit.SECONDS).toEpochMilli());
+    }
+
+    public Lease(@JsonProperty("leasedBy") String leasedBy, @JsonProperty("leasedAt") long leasedAt, @JsonProperty("leasedUntil") long leasedUntil) {
+        this.leasedBy = leasedBy;
+        this.leasedAt = leasedAt;
+        this.leasedUntil = leasedUntil;
+    }
+
+    public String getLeasedBy() {
+        return leasedBy;
+    }
+
+    public long getLeasedAt() {
+        return leasedAt;
+    }
+
+    public long getLeasedUntil() {
+        return leasedUntil;
+    }
+}

--- a/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/model/TransferProcessDocument.java
+++ b/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/model/TransferProcessDocument.java
@@ -55,7 +55,15 @@ public class TransferProcessDocument {
         return lease;
     }
 
-    private static class Lease {
+    public void lease(String connectorId) {
+        if (lease == null || lease.getLeasedBy().equals(connectorId)) {
+            lease = new Lease(connectorId, System.currentTimeMillis());
+        } else {
+            throw new IllegalStateException("This document is leased by " + lease.getLeasedBy() + " and cannot be leased again!");
+        }
+    }
+
+    public static class Lease {
         @JsonProperty
         private final String leasedBy;
         @JsonProperty

--- a/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/model/TransferProcessDocument.java
+++ b/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/model/TransferProcessDocument.java
@@ -38,7 +38,7 @@ public class TransferProcessDocument {
     }
 
     public static TransferProcessDocument from(TransferProcess process, String partitionKey, String externalId) {
-        return new TransferProcessDocument(process, partitionKey, externalId);
+        return new TransferProcessDocument(process, partitionKey, process.getDataRequest().getId());
     }
 
 

--- a/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/model/TransferProcessDocument.java
+++ b/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/model/TransferProcessDocument.java
@@ -21,6 +21,9 @@ public class TransferProcessDocument {
     @JsonProperty
     private String partitionKey;
 
+    @JsonProperty
+    private Lease lease;
+
     protected TransferProcessDocument() {
         //Jackson does not yet support the combination of @JsonUnwrapped and a @JsonProperty annotation in a constructor
     }
@@ -31,8 +34,8 @@ public class TransferProcessDocument {
         this.externalId = externalId;
     }
 
-    public static TransferProcessDocument from(TransferProcess process, String externalId) {
-        return new TransferProcessDocument(process, process.getId(), externalId);
+    public static TransferProcessDocument from(TransferProcess process, String partitionKey, String externalId) {
+        return new TransferProcessDocument(process, partitionKey, externalId);
     }
 
 
@@ -46,5 +49,29 @@ public class TransferProcessDocument {
 
     public String getExternalId() {
         return externalId;
+    }
+
+    public Lease getLease() {
+        return lease;
+    }
+
+    private static class Lease {
+        @JsonProperty
+        private final String leasedBy;
+        @JsonProperty
+        private final long leasedAt;
+
+        public Lease(@JsonProperty("leasedBy") String leasedBy, @JsonProperty("leasedAt") long leasedAt) {
+            this.leasedBy = leasedBy;
+            this.leasedAt = leasedAt;
+        }
+
+        public String getLeasedBy() {
+            return leasedBy;
+        }
+
+        public long getLeasedAt() {
+            return leasedAt;
+        }
     }
 }

--- a/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/model/TransferProcessDocument.java
+++ b/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/model/TransferProcessDocument.java
@@ -14,6 +14,7 @@ import com.microsoft.dagx.spi.types.domain.transfer.TransferProcess;
 @JsonTypeName("dagx:transferprocessdocument")
 public class TransferProcessDocument {
 
+    private String externalId;
     @JsonUnwrapped
     private TransferProcess wrappedInstance;
 
@@ -24,13 +25,14 @@ public class TransferProcessDocument {
         //Jackson does not yet support the combination of @JsonUnwrapped and a @JsonProperty annotation in a constructor
     }
 
-    private TransferProcessDocument(TransferProcess wrappedInstance, String partitionKey) {
+    private TransferProcessDocument(TransferProcess wrappedInstance, String partitionKey, String externalId) {
         this.wrappedInstance = wrappedInstance;
         this.partitionKey = partitionKey;
+        this.externalId = externalId;
     }
 
-    public static TransferProcessDocument from(TransferProcess process) {
-        return new TransferProcessDocument(process, process.getId());
+    public static TransferProcessDocument from(TransferProcess process, String externalId) {
+        return new TransferProcessDocument(process, process.getId(), externalId);
     }
 
 
@@ -40,5 +42,9 @@ public class TransferProcessDocument {
 
     public TransferProcess getWrappedInstance() {
         return wrappedInstance;
+    }
+
+    public String getExternalId() {
+        return externalId;
     }
 }

--- a/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/model/TransferProcessDocument.java
+++ b/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/model/TransferProcessDocument.java
@@ -15,7 +15,7 @@ import com.microsoft.dagx.spi.types.domain.transfer.TransferProcess;
 public class TransferProcessDocument {
 
     @JsonUnwrapped
-    public TransferProcess wrappedInstance;
+    private TransferProcess wrappedInstance;
 
     @JsonProperty
     private String partitionKey;
@@ -29,8 +29,8 @@ public class TransferProcessDocument {
         this.partitionKey = partitionKey;
     }
 
-    public static TransferProcessDocument from(TransferProcess process, String partitionKey) {
-        return new TransferProcessDocument(process, partitionKey);
+    public static TransferProcessDocument from(TransferProcess process) {
+        return new TransferProcessDocument(process, process.getId());
     }
 
 
@@ -38,4 +38,7 @@ public class TransferProcessDocument {
         return partitionKey;
     }
 
+    public TransferProcess getWrappedInstance() {
+        return wrappedInstance;
+    }
 }

--- a/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/model/TransferProcessDocument.java
+++ b/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/model/TransferProcessDocument.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *  All rights reserved.
+ *
+ */
+
+package com.microsoft.dagx.transfer.store.cosmos.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.microsoft.dagx.spi.types.domain.transfer.TransferProcess;
+
+@JsonTypeName("dagx:transferprocessdocument")
+public class TransferProcessDocument {
+
+    @JsonUnwrapped
+    public TransferProcess wrappedInstance;
+
+    @JsonProperty
+    private String partitionKey;
+
+    protected TransferProcessDocument() {
+        //Jackson does not yet support the combination of @JsonUnwrapped and a @JsonProperty annotation in a constructor
+    }
+
+    private TransferProcessDocument(TransferProcess wrappedInstance, String partitionKey) {
+        this.wrappedInstance = wrappedInstance;
+        this.partitionKey = partitionKey;
+    }
+
+    public static TransferProcessDocument from(TransferProcess process, String partitionKey) {
+        return new TransferProcessDocument(process, partitionKey);
+    }
+
+
+    public String getPartitionKey() {
+        return partitionKey;
+    }
+
+}

--- a/extensions/transfer/transfer-store-cosmos/src/main/resources/META-INF/services/com.microsoft.dagx.spi.system.ServiceExtension
+++ b/extensions/transfer/transfer-store-cosmos/src/main/resources/META-INF/services/com.microsoft.dagx.spi.system.ServiceExtension
@@ -1,0 +1,2 @@
+com.microsoft.dagx.transfer.store.cosmos.CosmosTransferProcessStoreExtension
+

--- a/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreTest.java
+++ b/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreTest.java
@@ -16,6 +16,7 @@ import com.azure.cosmos.models.CosmosDatabaseResponse;
 import com.azure.cosmos.models.PartitionKey;
 import com.azure.cosmos.util.CosmosPagedIterable;
 import com.microsoft.dagx.spi.DagxException;
+import com.microsoft.dagx.spi.types.TypeManager;
 import com.microsoft.dagx.spi.types.domain.transfer.TransferProcess;
 import com.microsoft.dagx.spi.types.domain.transfer.TransferProcessStates;
 import com.microsoft.dagx.transfer.store.cosmos.model.TransferProcessDocument;
@@ -67,7 +68,7 @@ class CosmosTransferProcessStoreTest {
     void setUp() {
         final CosmosContainerResponse containerIfNotExists = database.createContainerIfNotExists(containerName, "/partitionKey");
         container = database.getContainer(containerIfNotExists.getProperties().getId());
-        store = new CosmosTransferProcessStore(container);
+        store = new CosmosTransferProcessStore(container, new TypeManager());
     }
 
     @Test

--- a/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreTest.java
+++ b/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -32,7 +33,7 @@ import static com.microsoft.dagx.transfer.store.cosmos.TestHelper.createTransfer
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-//@EnabledIfEnvironmentVariable(named = "CI", matches = "true")
+@EnabledIfEnvironmentVariable(named = "CI", matches = "true")
 class CosmosTransferProcessStoreTest {
 
     private final static String accountName = "cosmos-itest";

--- a/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreTest.java
+++ b/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -34,6 +35,7 @@ import static com.microsoft.dagx.transfer.store.cosmos.TestHelper.createTransfer
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@EnabledIfEnvironmentVariable(named = "CI", matches = "true")
 class CosmosTransferProcessStoreTest {
 
     private final static String accountName = "cosmos-itest";
@@ -46,9 +48,8 @@ class CosmosTransferProcessStoreTest {
     @BeforeAll
     static void prepareCosmosClient() {
 
-        var key = propOrEnv("COSMOS_KEY", () -> {
-            throw new RuntimeException("No COSMOS_KEY was found!");
-        });
+        var key = propOrEnv("COSMOS_KEY", null);
+        assertThat(key).describedAs("COSMOS_KEY cannot be null!").isNotNull();
         var client = new CosmosClientBuilder()
                 .key(key)
                 .preferredRegions(Collections.singletonList("westeurope"))

--- a/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreTest.java
+++ b/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *  All rights reserved.
+ *
+ */
+
+package com.microsoft.dagx.transfer.store.cosmos;
+
+import com.azure.cosmos.ConsistencyLevel;
+import com.azure.cosmos.CosmosClientBuilder;
+import com.azure.cosmos.CosmosContainer;
+import com.azure.cosmos.CosmosDatabase;
+import com.azure.cosmos.implementation.ConflictException;
+import com.azure.cosmos.models.CosmosContainerResponse;
+import com.azure.cosmos.models.CosmosDatabaseResponse;
+import com.azure.cosmos.models.PartitionKey;
+import com.azure.cosmos.util.CosmosPagedIterable;
+import com.microsoft.dagx.spi.DagxException;
+import com.microsoft.dagx.spi.types.domain.transfer.TransferProcess;
+import com.microsoft.dagx.spi.types.domain.transfer.TransferProcessStates;
+import com.microsoft.dagx.transfer.store.cosmos.model.TransferProcessDocument;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static com.microsoft.dagx.common.ConfigurationFunctions.propOrEnv;
+import static com.microsoft.dagx.transfer.store.cosmos.TestHelper.createTransferProcess;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CosmosTransferProcessStoreTest {
+
+    private final static String accountName = "cosmos-itest";
+    private final static String databaseName = "connector-itest";
+    private final static String containerName = "CosmosTransferProcessStoreTest";
+    private static CosmosContainer container;
+    private static CosmosDatabase database;
+    private CosmosTransferProcessStore store;
+
+    @BeforeAll
+    static void prepareCosmosClient() {
+
+        var key = propOrEnv("COSMOS_KEY", () -> {
+            throw new RuntimeException("No COSMOS_KEY was found!");
+        });
+        var client = new CosmosClientBuilder()
+                .key(key)
+                .preferredRegions(Collections.singletonList("westeurope"))
+                .consistencyLevel(ConsistencyLevel.SESSION)
+                .endpoint("https://" + accountName + ".documents.azure.com:443/")
+                .buildClient();
+
+        final CosmosDatabaseResponse response = client.createDatabaseIfNotExists(databaseName);
+        database = client.getDatabase(response.getProperties().getId());
+
+
+    }
+
+    @BeforeEach
+    void setUp() {
+        final CosmosContainerResponse containerIfNotExists = database.createContainerIfNotExists(containerName, "/partitionKey");
+        container = database.getContainer(containerIfNotExists.getProperties().getId());
+        store = new CosmosTransferProcessStore(container);
+    }
+
+    @Test
+    void create() {
+        final String id = UUID.randomUUID().toString();
+        TransferProcess transferProcess = createTransferProcess(id);
+        store.create(transferProcess);
+
+        final CosmosPagedIterable<TransferProcessDocument> documents = container.readAllItems(new PartitionKey(id), TransferProcessDocument.class);
+        assertThat(documents).hasSize(1);
+        assertThat(documents).allSatisfy(doc -> {
+            assertThat(doc.getWrappedInstance()).isNotNull();
+            assertThat(doc.getWrappedInstance().getId()).isEqualTo(id);
+            assertThat(doc.getPartitionKey()).isEqualTo(id);
+        });
+    }
+
+    @Test
+    void create_processWithSameIdExists_throwsException() {
+        final String id = UUID.randomUUID().toString();
+        TransferProcess transferProcess = createTransferProcess(id);
+        store.create(transferProcess);
+
+        var secondProcess = createTransferProcess(id);
+
+        assertThatThrownBy(() -> store.create(secondProcess)).isInstanceOf(DagxException.class).hasRootCauseInstanceOf(ConflictException.class);
+    }
+
+    @Test
+    void nextForState() throws InterruptedException {
+
+        String id1 = UUID.randomUUID().toString();
+        var tp = createTransferProcess(id1, TransferProcessStates.PROVISIONED);
+
+        String id2 = UUID.randomUUID().toString();
+        var tp2 = createTransferProcess(id2, TransferProcessStates.PROVISIONED);
+
+        Thread.sleep(500); //make sure the third process is the youngest - should not get fetched
+        String id3 = UUID.randomUUID().toString();
+        var tp3 = createTransferProcess(id3, TransferProcessStates.PROVISIONED);
+
+        store.create(tp);
+        store.create(tp2);
+        store.create(tp3);
+
+
+        final List<TransferProcess> processes = store.nextForState(TransferProcessStates.PROVISIONED.code(), 2);
+
+        assertThat(processes).hasSize(2);
+        //lets make sure the list only contains the 2 oldest ones
+        assertThat(processes).allMatch(p -> Arrays.asList(id1, id2).contains(p.getId()))
+                .noneMatch(p -> p.getId().equals(id3));
+    }
+
+    @Test
+    void nextForState_noneInDesiredState() {
+
+        String id1 = UUID.randomUUID().toString();
+        var tp = createTransferProcess(id1, TransferProcessStates.PROVISIONED);
+
+        String id2 = UUID.randomUUID().toString();
+        var tp2 = createTransferProcess(id2, TransferProcessStates.PROVISIONED);
+
+        String id3 = UUID.randomUUID().toString();
+        var tp3 = createTransferProcess(id3, TransferProcessStates.PROVISIONED);
+
+        store.create(tp);
+        store.create(tp2);
+        store.create(tp3);
+
+        final List<TransferProcess> processes = store.nextForState(TransferProcessStates.IN_PROGRESS.code(), 5);
+
+        assertThat(processes).isEmpty();
+    }
+
+    @Test
+    void nextForState_batchSizeLimits() {
+        for (var i = 0; i < 5; i++) {
+            var tp = createTransferProcess("process_" + i, TransferProcessStates.IN_PROGRESS);
+            store.create(tp);
+        }
+
+        var processes = store.nextForState(TransferProcessStates.IN_PROGRESS.code(), 3);
+        assertThat(processes).hasSize(3);
+    }
+
+
+    @AfterEach
+    void teardown() {
+        final CosmosContainerResponse delete = container.delete();
+        assertThat(delete.getStatusCode()).isGreaterThanOrEqualTo(200).isLessThan(300);
+    }
+}

--- a/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreTest.java
+++ b/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreTest.java
@@ -48,7 +48,7 @@ class CosmosTransferProcessStoreTest {
     @BeforeAll
     static void prepareCosmosClient() {
 
-        var key = propOrEnv("COSMOS_KEY", "RYNecVDtJq2WKAcIoONBLzuTBys06kUcP8Rw9Yz5zOzsOQFVGaP8oGuI5qgF5ONQY4VukjkpQ4x7a2jwVvo7SQ==");
+        var key = propOrEnv("COSMOS_KEY", null);
         assertThat(key).describedAs("COSMOS_KEY cannot be null!").isNotNull();
         var client = new CosmosClientBuilder()
                 .key(key)

--- a/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreTest.java
+++ b/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreTest.java
@@ -140,7 +140,7 @@ class CosmosTransferProcessStoreTest {
         store.create(tp2);
         final CosmosItemResponse<Object> response = container.readItem(id2, new PartitionKey(partitionKey), Object.class);
         final TransferProcessDocument item = convert(response.getItem());
-        item.lease("test-leaser");
+        item.acquireLease("test-leaser");
         container.upsertItem(item);
 
 
@@ -154,7 +154,7 @@ class CosmosTransferProcessStoreTest {
     void nextForState_selfCanLeaseAgain() {
         var tp1 = createTransferProcess("process1", TransferProcessStates.INITIAL);
         var doc = TransferProcessDocument.from(tp1, partitionKey, "extid1");
-        doc.lease("dagx-connector");
+        doc.acquireLease("dagx-connector");
         var originalTs = doc.getLease().getLeasedAt();
         container.upsertItem(doc);
 
@@ -175,9 +175,9 @@ class CosmosTransferProcessStoreTest {
         var tp2 = createTransferProcess(id2, TransferProcessStates.INITIAL);
 
         var d1 = TransferProcessDocument.from(tp, partitionKey, "extid1");
-        d1.lease("another-connector");
+        d1.acquireLease("another-connector");
         var d2 = TransferProcessDocument.from(tp2, partitionKey, "extid2");
-        d2.lease("a-third-connector");
+        d2.acquireLease("a-third-connector");
 
         container.upsertItem(d1);
         container.upsertItem(d2);

--- a/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreTest.java
+++ b/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -33,7 +34,7 @@ import static com.microsoft.dagx.transfer.store.cosmos.TestHelper.createTransfer
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-//@EnabledIfEnvironmentVariable(named = "CI", matches = "true")
+@EnabledIfEnvironmentVariable(named = "CI", matches = "true")
 class CosmosTransferProcessStoreTest {
 
     private final static String accountName = "cosmos-itest";
@@ -49,12 +50,12 @@ class CosmosTransferProcessStoreTest {
     @BeforeAll
     static void prepareCosmosClient() {
 
-//        var isCi = propOrEnv("CI", "false");
-//        if (!Boolean.parseBoolean(isCi)) {
-//            return;
-//        }
+        var isCi = propOrEnv("CI", "false");
+        if (!Boolean.parseBoolean(isCi)) {
+            return;
+        }
 
-        var key = propOrEnv("COSMOS_KEY", "RYNecVDtJq2WKAcIoONBLzuTBys06kUcP8Rw9Yz5zOzsOQFVGaP8oGuI5qgF5ONQY4VukjkpQ4x7a2jwVvo7SQ==");
+        var key = propOrEnv("COSMOS_KEY", null);
         assertThat(key).describedAs("COSMOS_KEY cannot be null!").isNotNull();
         var client = new CosmosClientBuilder()
                 .key(key)

--- a/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreTest.java
+++ b/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreTest.java
@@ -160,7 +160,7 @@ class CosmosTransferProcessStoreTest {
     @Test
     void nextForState_selfCanLeaseAgain() {
         var tp1 = createTransferProcess("process1", TransferProcessStates.INITIAL);
-        var doc = TransferProcessDocument.from(tp1, partitionKey, "extid1");
+        var doc = TransferProcessDocument.from(tp1, partitionKey);
         doc.acquireLease("dagx-connector");
         var originalTs = doc.getLease().getLeasedAt();
         container.upsertItem(doc);
@@ -180,9 +180,9 @@ class CosmosTransferProcessStoreTest {
         String id2 = "process2";
         var tp2 = createTransferProcess(id2, TransferProcessStates.INITIAL);
 
-        var d1 = TransferProcessDocument.from(tp, partitionKey, "extid1");
+        var d1 = TransferProcessDocument.from(tp, partitionKey);
         d1.acquireLease("another-connector");
-        var d2 = TransferProcessDocument.from(tp2, partitionKey, "extid2");
+        var d2 = TransferProcessDocument.from(tp2, partitionKey);
         d2.acquireLease("a-third-connector");
 
         container.upsertItem(d1);
@@ -293,7 +293,7 @@ class CosmosTransferProcessStoreTest {
     void update_leasedBySelf() {
         var tp = createTransferProcess("proc1", TransferProcessStates.INITIAL);
 
-        var doc = TransferProcessDocument.from(tp, partitionKey, "ext-id");
+        var doc = TransferProcessDocument.from(tp, partitionKey);
         container.upsertItem(doc).getItem();
         doc.acquireLease("dagx-connector");
         container.upsertItem(doc);
@@ -310,7 +310,7 @@ class CosmosTransferProcessStoreTest {
         var tp = createTransferProcess("proc1", TransferProcessStates.INITIAL);
 
         //simulate another connector
-        var doc = TransferProcessDocument.from(tp, partitionKey, "ext-id");
+        var doc = TransferProcessDocument.from(tp, partitionKey);
         container.upsertItem(doc).getItem();
 
         doc.acquireLease("another-connector");
@@ -339,7 +339,7 @@ class CosmosTransferProcessStoreTest {
     void delete_isLeased_shouldThrowException() {
         final String processId = "test-process-id";
         var tp = createTransferProcess(processId);
-        var doc = TransferProcessDocument.from(tp, partitionKey, "some-extid");
+        var doc = TransferProcessDocument.from(tp, partitionKey);
         doc.acquireLease("some-other-connector");
         container.upsertItem(doc);
 
@@ -350,7 +350,7 @@ class CosmosTransferProcessStoreTest {
     void delete_isLeasedBySelf() {
         final String processId = "test-process-id";
         var tp = createTransferProcess(processId);
-        var doc = TransferProcessDocument.from(tp, partitionKey, "some-extid");
+        var doc = TransferProcessDocument.from(tp, partitionKey);
         doc.acquireLease("dagx-connector");
         container.upsertItem(doc);
 

--- a/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/TestHelper.java
+++ b/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/TestHelper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *  All rights reserved.
+ *
+ */
+
+package com.microsoft.dagx.transfer.store.cosmos;
+
+import com.microsoft.dagx.spi.types.domain.transfer.*;
+
+public class TestHelper {
+
+    public static ResourceManifest createManifest() {
+        return ResourceManifest.Builder.newInstance()
+                .build();
+    }
+
+    public static DataRequest createDataRequest() {
+        return DataRequest.Builder.newInstance()
+                .dataDestination(DataAddress.Builder.newInstance()
+                        .type("Test Address Type")
+                        .keyName("Test Key Name")
+                        .build())
+                .processId("test-process-id")
+                .build();
+    }
+
+    public static TransferProcess createTransferProcess() {
+        return createTransferProcess("test-process");
+    }
+
+    public static TransferProcess createTransferProcess(String processId, TransferProcessStates state) {
+        return TransferProcess.Builder.newInstance()
+                .id(processId)
+                .state(state.code())
+                .type(TransferProcess.Type.CLIENT)
+                .dataRequest(createDataRequest())
+                .resourceManifest(createManifest())
+                .build();
+    }
+
+    public static TransferProcess createTransferProcess(String processId) {
+        return createTransferProcess(processId, TransferProcessStates.UNSAVED);
+    }
+}

--- a/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/TestHelper.java
+++ b/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/TestHelper.java
@@ -19,6 +19,7 @@ public class TestHelper {
 
     public static DataRequest createDataRequest() {
         return DataRequest.Builder.newInstance()
+                .id("request-id")
                 .dataDestination(DataAddress.Builder.newInstance()
                         .type("Test Address Type")
                         .keyName("Test Key Name")

--- a/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/TestHelper.java
+++ b/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/TestHelper.java
@@ -6,6 +6,8 @@
 
 package com.microsoft.dagx.transfer.store.cosmos;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.microsoft.dagx.spi.types.domain.metadata.DataEntry;
 import com.microsoft.dagx.spi.types.domain.transfer.*;
 
 public class TestHelper {
@@ -20,6 +22,10 @@ public class TestHelper {
                 .dataDestination(DataAddress.Builder.newInstance()
                         .type("Test Address Type")
                         .keyName("Test Key Name")
+                        .build())
+                .dataEntry(DataEntry.Builder.newInstance()
+                        .policyId("test-policyId")
+                        .catalogEntry(new DummyCatalogEntry())
                         .build())
                 .processId("test-process-id")
                 .build();
@@ -41,5 +47,13 @@ public class TestHelper {
 
     public static TransferProcess createTransferProcess(String processId) {
         return createTransferProcess(processId, TransferProcessStates.UNSAVED);
+    }
+
+    @JsonTypeName("dagx:dummycatalogentry")
+    public static class DummyCatalogEntry implements com.microsoft.dagx.spi.types.domain.metadata.DataCatalogEntry {
+        @Override
+        public DataAddress getAddress() {
+            return DataAddress.Builder.newInstance().type("test-source-type").build();
+        }
     }
 }

--- a/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/model/TransferProcessDocumentSerializationTest.java
+++ b/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/model/TransferProcessDocumentSerializationTest.java
@@ -7,6 +7,7 @@
 package com.microsoft.dagx.transfer.store.cosmos.model;
 
 import com.microsoft.dagx.spi.types.TypeManager;
+import com.microsoft.dagx.spi.types.domain.metadata.DataCatalogEntry;
 import com.microsoft.dagx.spi.types.domain.transfer.TransferProcess;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,7 @@ class TransferProcessDocumentSerializationTest {
     @BeforeEach
     void setup() {
         typeManager = new TypeManager();
+        typeManager.registerTypes(DummyCatalogEntry.class, DataCatalogEntry.class);
         typeManager.registerTypes(TransferProcessDocument.class, TransferProcess.class);
     }
 
@@ -29,7 +31,7 @@ class TransferProcessDocumentSerializationTest {
 
         var transferProcess = createTransferProcess();
 
-        var document = TransferProcessDocument.from(transferProcess);
+        var document = TransferProcessDocument.from(transferProcess, transferProcess.getDataRequest().getId());
 
         final String s = typeManager.writeValueAsString(document);
 
@@ -42,6 +44,7 @@ class TransferProcessDocumentSerializationTest {
         assertThat(s).contains("\"destinationType\":\"Test Address Type\"");
         assertThat(s).contains("\"keyName\":\"Test Key Name\"");
         assertThat(s).contains("\"type\":\"Test Address Type\"");
+        assertThat(s).contains("dummycatalogentry");
 
     }
 
@@ -54,10 +57,10 @@ class TransferProcessDocumentSerializationTest {
                 .resourceManifest(createManifest())
                 .build();
 
-        var document = TransferProcessDocument.from(transferProcess);
+        var document = TransferProcessDocument.from(transferProcess, transferProcess.getDataRequest().getId());
         final String json = typeManager.writeValueAsString(document);
 
-        Object transferProcessDeserialized = typeManager.readValue(json, TransferProcessDocument.class);
+        var transferProcessDeserialized = typeManager.readValue(json, TransferProcessDocument.class);
         assertThat(transferProcessDeserialized).usingRecursiveComparison().isEqualTo(document);
 
     }

--- a/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/model/TransferProcessDocumentSerializationTest.java
+++ b/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/model/TransferProcessDocumentSerializationTest.java
@@ -31,7 +31,7 @@ class TransferProcessDocumentSerializationTest {
 
         var transferProcess = createTransferProcess();
 
-        var document = TransferProcessDocument.from(transferProcess, transferProcess.getDataRequest().getId());
+        var document = TransferProcessDocument.from(transferProcess, "test-process", transferProcess.getDataRequest().getId());
 
         final String s = typeManager.writeValueAsString(document);
 
@@ -57,7 +57,7 @@ class TransferProcessDocumentSerializationTest {
                 .resourceManifest(createManifest())
                 .build();
 
-        var document = TransferProcessDocument.from(transferProcess, transferProcess.getDataRequest().getId());
+        var document = TransferProcessDocument.from(transferProcess, "test-process", transferProcess.getDataRequest().getId());
         final String json = typeManager.writeValueAsString(document);
 
         var transferProcessDeserialized = typeManager.readValue(json, TransferProcessDocument.class);

--- a/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/model/TransferProcessDocumentSerializationTest.java
+++ b/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/model/TransferProcessDocumentSerializationTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *  All rights reserved.
+ *
+ */
+
+package com.microsoft.dagx.transfer.store.cosmos.model;
+
+import com.microsoft.dagx.spi.types.TypeManager;
+import com.microsoft.dagx.spi.types.domain.transfer.DataAddress;
+import com.microsoft.dagx.spi.types.domain.transfer.DataRequest;
+import com.microsoft.dagx.spi.types.domain.transfer.ResourceManifest;
+import com.microsoft.dagx.spi.types.domain.transfer.TransferProcess;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TransferProcessDocumentSerializationTest {
+
+    private TypeManager typeManager;
+
+    @BeforeEach
+    void setup() {
+        typeManager = new TypeManager();
+        typeManager.registerTypes(TransferProcessDocument.class, TransferProcess.class);
+    }
+
+    @Test
+    void testSerialization() {
+        var transferProcess = TransferProcess.Builder.newInstance()
+                .id("test-process")
+                .type(TransferProcess.Type.CLIENT)
+                .dataRequest(createDataRequest())
+                .resourceManifest(createManifest())
+                .build();
+
+        var document = TransferProcessDocument.from(transferProcess, "test-part-key");
+
+        final String s = typeManager.writeValueAsString(document);
+
+        assertThat(s).isNotNull();
+        assertThat(s).contains("\"partitionKey\":\"test-part-key\"");
+        assertThat(s).contains("\"id\":\"test-process\"");
+        assertThat(s).contains("\"id\":\"test-process\"");
+        assertThat(s).contains("\"type\":\"CLIENT\"");
+        assertThat(s).contains("\"errorDetail\":null");
+        assertThat(s).contains("\"destinationType\":\"Test Address Type\"");
+        assertThat(s).contains("\"keyName\":\"Test Key Name\"");
+        assertThat(s).contains("\"type\":\"Test Address Type\"");
+
+    }
+
+    @Test
+    void testDeserialization() {
+        var transferProcess = TransferProcess.Builder.newInstance()
+                .id("test-process")
+                .type(TransferProcess.Type.CLIENT)
+                .dataRequest(createDataRequest())
+                .resourceManifest(createManifest())
+                .build();
+
+        var document = TransferProcessDocument.from(transferProcess, "test-part-key");
+        final String json = typeManager.writeValueAsString(document);
+
+        Object transferProcessDeserialized = typeManager.readValue(json, TransferProcessDocument.class);
+        assertThat(transferProcessDeserialized).usingRecursiveComparison().isEqualTo(document);
+
+    }
+
+    private ResourceManifest createManifest() {
+        return ResourceManifest.Builder.newInstance()
+                .build();
+    }
+
+    private DataRequest createDataRequest() {
+        return DataRequest.Builder.newInstance()
+                .dataDestination(DataAddress.Builder.newInstance()
+                        .type("Test Address Type")
+                        .keyName("Test Key Name")
+                        .build())
+                .processId("test-process-id")
+                .build();
+    }
+}

--- a/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/model/TransferProcessDocumentSerializationTest.java
+++ b/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/model/TransferProcessDocumentSerializationTest.java
@@ -31,7 +31,7 @@ class TransferProcessDocumentSerializationTest {
 
         var transferProcess = createTransferProcess();
 
-        var document = TransferProcessDocument.from(transferProcess, "test-process", transferProcess.getDataRequest().getId());
+        var document = TransferProcessDocument.from(transferProcess, "test-process");
 
         final String s = typeManager.writeValueAsString(document);
 
@@ -57,7 +57,7 @@ class TransferProcessDocumentSerializationTest {
                 .resourceManifest(createManifest())
                 .build();
 
-        var document = TransferProcessDocument.from(transferProcess, "test-process", transferProcess.getDataRequest().getId());
+        var document = TransferProcessDocument.from(transferProcess, "test-process");
         final String json = typeManager.writeValueAsString(document);
 
         var transferProcessDeserialized = typeManager.readValue(json, TransferProcessDocument.class);

--- a/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/model/TransferProcessDocumentSerializationTest.java
+++ b/extensions/transfer/transfer-store-cosmos/src/test/java/com/microsoft/dagx/transfer/store/cosmos/model/TransferProcessDocumentSerializationTest.java
@@ -7,13 +7,11 @@
 package com.microsoft.dagx.transfer.store.cosmos.model;
 
 import com.microsoft.dagx.spi.types.TypeManager;
-import com.microsoft.dagx.spi.types.domain.transfer.DataAddress;
-import com.microsoft.dagx.spi.types.domain.transfer.DataRequest;
-import com.microsoft.dagx.spi.types.domain.transfer.ResourceManifest;
 import com.microsoft.dagx.spi.types.domain.transfer.TransferProcess;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static com.microsoft.dagx.transfer.store.cosmos.TestHelper.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class TransferProcessDocumentSerializationTest {
@@ -28,19 +26,15 @@ class TransferProcessDocumentSerializationTest {
 
     @Test
     void testSerialization() {
-        var transferProcess = TransferProcess.Builder.newInstance()
-                .id("test-process")
-                .type(TransferProcess.Type.CLIENT)
-                .dataRequest(createDataRequest())
-                .resourceManifest(createManifest())
-                .build();
 
-        var document = TransferProcessDocument.from(transferProcess, "test-part-key");
+        var transferProcess = createTransferProcess();
+
+        var document = TransferProcessDocument.from(transferProcess);
 
         final String s = typeManager.writeValueAsString(document);
 
         assertThat(s).isNotNull();
-        assertThat(s).contains("\"partitionKey\":\"test-part-key\"");
+        assertThat(s).contains("\"partitionKey\":\"test-process\""); //should use the process id as partition key
         assertThat(s).contains("\"id\":\"test-process\"");
         assertThat(s).contains("\"id\":\"test-process\"");
         assertThat(s).contains("\"type\":\"CLIENT\"");
@@ -60,7 +54,7 @@ class TransferProcessDocumentSerializationTest {
                 .resourceManifest(createManifest())
                 .build();
 
-        var document = TransferProcessDocument.from(transferProcess, "test-part-key");
+        var document = TransferProcessDocument.from(transferProcess);
         final String json = typeManager.writeValueAsString(document);
 
         Object transferProcessDeserialized = typeManager.readValue(json, TransferProcessDocument.class);
@@ -68,18 +62,5 @@ class TransferProcessDocumentSerializationTest {
 
     }
 
-    private ResourceManifest createManifest() {
-        return ResourceManifest.Builder.newInstance()
-                .build();
-    }
 
-    private DataRequest createDataRequest() {
-        return DataRequest.Builder.newInstance()
-                .dataDestination(DataAddress.Builder.newInstance()
-                        .type("Test Address Type")
-                        .keyName("Test Key Name")
-                        .build())
-                .processId("test-process-id")
-                .build();
-    }
 }

--- a/extensions/transfer/transfer-store-cosmos/src/test/resources/lease.js
+++ b/extensions/transfer/transfer-store-cosmos/src/test/resources/lease.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *  All rights reserved.
+ *
+ */
+
+function lease(processId, connectorId, shouldLease) {
+    var context = getContext();
+    var collection = context.getCollection();
+    var collectionLink = collection.getSelfLink();
+    var response = context.getResponse();
+
+
+    // first query
+    var filterQuery = {
+        'query': 'SELECT * FROM TransferProcessDocuments t WHERE t.id = @processId',
+        'parameters': [
+            {
+                'name': '@processId', 'value': processId
+            }
+        ]
+    };
+
+    var accept = collection.queryDocuments(collectionLink, filterQuery, {}, function (err, items, responseOptions) {
+        if (err) throw new Error("Error" + err.message);
+
+
+        if (!items || !items.length) {
+            let err = "No documents found!";
+            response.setBody(err)
+            console.log(err)
+            return;
+        }
+        if (items.length > 1) {
+            let err = "too many docs found for query: expected 1, got " + items.length;
+            console.log(err);
+            throw err;
+        }
+
+        let document = items[0];
+
+        if (document.lease != null && document.lease.leasedBy !== connectorId) {
+            throw "Document is locked by another connector"
+        }
+
+        if (shouldLease)
+            lease(document, connectorId);
+        else //clear lease
+            document.lease = null;
+
+
+        response.setBody(document)
+    });
+
+    if (!accept) throw "Unable to read document details, abort ";
+
+    function lease(document, connectorId) {
+        document.lease = {
+            leasedBy: connectorId,
+            leasedAt: Date.now()
+        };
+
+        var accept = collection.replaceDocument(document._self, document, function (err, itemReplaced) {
+            if (err) throw "Unable to update Document, abort ";
+        })
+        if (!accept) throw "Unable to update Document, abort";
+        console.log("updated lease of document " + document.id)
+    }
+}

--- a/extensions/transfer/transfer-store-cosmos/src/test/resources/nextForState.js
+++ b/extensions/transfer/transfer-store-cosmos/src/test/resources/nextForState.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *  All rights reserved.
+ *
+ */
+
+function nextForState(state, limit, connectorId) {
+    var context = getContext();
+    var collection = context.getCollection();
+    var collectionLink = collection.getSelfLink();
+    var response = context.getResponse();
+
+
+    // first query
+    var filterQuery = {
+        'query': 'SELECT * FROM TransferProcessDocuments t WHERE t.state = @state AND t.lease = null ORDER BY t.stateTimestamp OFFSET 0 LIMIT @limit',
+        'parameters': [{'name': '@state', 'value': parseInt(state, 10)}, {
+            'name': '@limit',
+            'value': parseInt(limit, 10)
+        }]
+    };
+
+    var accept = collection.queryDocuments(collectionLink, filterQuery, {}, function (err, items, responseOptions) {
+        if (err) throw new Error("Error" + err.message);
+
+
+        if (!items || !items.length || items.length <= 0) {
+            response.setBody('no docs found')
+            console.log("No documents found!")
+        }
+
+        console.log("found " + items.length + " documents!")
+
+        // add lock to all items
+        for (var i = 0; i < items.length; i++) {
+            lease(items[0], connectorId)
+        }
+        var body = items;
+        response.setBody(body)
+    });
+
+    if (!accept) throw "Unable to read player details, abort ";
+
+    function lease(document, connectorId) {
+        document.lease = {
+            leasedBy: connectorId,
+            leasedAt: Date.now()
+        };
+
+        var accept = collection.replaceDocument(document._self, document, function (err, itemReplaced) {
+            if (err) throw "Unable to update Document, abort ";
+        })
+        if (!accept) throw "Unable to update Document, abort";
+        console.log("updated lease of document " + document.id)
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,4 @@ jwtVersion=3.13.0
 awsVersion=2.16.60
 jodahFailsafeVersion=2.4.0
 storageBlobVersion=12.11.0
+cosmosSdkVersion=4.4.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,4 @@ jwtVersion=3.13.0
 awsVersion=2.16.60
 jodahFailsafeVersion=2.4.0
 storageBlobVersion=12.11.0
-cosmosSdkVersion=4.4.0
+cosmosSdkVersion=4.16.0

--- a/integration/integration-core/src/test/java/ClientRunner.java
+++ b/integration/integration-core/src/test/java/ClientRunner.java
@@ -161,7 +161,7 @@ public class ClientRunner {
         extension.registerSystemExtension(ServiceExtension.class, TestExtensions.mockIamExtension(identityService));
     }
 
-    private DataRequest createRequestAws(String id, DataEntry<?> artifactId) {
+    private DataRequest createRequestAws(String id, DataEntry artifactId) {
         return DataRequest.Builder.newInstance()
                 .id(id)
                 .protocol("ids-rest")
@@ -171,7 +171,7 @@ public class ClientRunner {
                 .destinationType(S3BucketSchema.TYPE).build();
     }
 
-    private DataRequest createRequestAzure(String id, DataEntry<?> artifactId) {
+    private DataRequest createRequestAzure(String id, DataEntry artifactId) {
         return DataRequest.Builder.newInstance()
                 .id(id)
                 .protocol("ids-rest")

--- a/integration/integration-core/src/test/java/ClientRunner.java
+++ b/integration/integration-core/src/test/java/ClientRunner.java
@@ -36,9 +36,6 @@ import java.util.stream.Collectors;
 import static com.microsoft.dagx.common.Cast.cast;
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- *
- */
 @ExtendWith(DagxExtension.class)
 @Disabled
 public class ClientRunner {
@@ -103,7 +100,7 @@ public class ClientRunner {
 
 
     @Test
-//    @Disabled
+    @Disabled
     void processClientRequest_toAzureStorage(RemoteMessageDispatcherRegistry dispatcherRegistry, TransferProcessManager processManager, TransferProcessObservable observable, TransferProcessStore store) throws Exception {
         var query = QueryRequest.Builder.newInstance()
                 .connectorAddress(PROVIDER_CONNECTOR)

--- a/integration/integration-core/src/test/java/ClientRunner.java
+++ b/integration/integration-core/src/test/java/ClientRunner.java
@@ -31,6 +31,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static com.microsoft.dagx.common.Cast.cast;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,7 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  */
 @ExtendWith(DagxExtension.class)
-@Disabled
+//@Disabled
 public class ClientRunner {
     private static final String PROVIDER_CONNECTOR = "http://dev-dagx.westeurope.azurecontainer.io:8181";
     private static final TokenResult US_TOKEN = TokenResult.Builder.newInstance().token("mock-us").build();
@@ -63,6 +64,7 @@ public class ClientRunner {
         CompletableFuture<List<String>> future = cast(dispatcherRegistry.send(List.class, query, () -> null));
 
         var artifacts = future.get();
+        artifacts = artifacts.stream().findAny().stream().collect(Collectors.toList());
         latch = new CountDownLatch(artifacts.size());
         for (String artifact : artifacts) {
             System.out.println("processing artifact " + artifact);
@@ -101,7 +103,7 @@ public class ClientRunner {
 
 
     @Test
-    @Disabled
+//    @Disabled
     void processClientRequest_toAzureStorage(RemoteMessageDispatcherRegistry dispatcherRegistry, TransferProcessManager processManager, TransferProcessObservable observable, TransferProcessStore store) throws Exception {
         var query = QueryRequest.Builder.newInstance()
                 .connectorAddress(PROVIDER_CONNECTOR)

--- a/integration/integration-core/src/test/java/ClientRunner.java
+++ b/integration/integration-core/src/test/java/ClientRunner.java
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(DagxExtension.class)
 @Disabled
 public class ClientRunner {
-    private static final String PROVIDER_CONNECTOR = "http:/localhost:8181";
+    private static final String PROVIDER_CONNECTOR = "http://dev-dagx.westeurope.azurecontainer.io:8181";
     private static final TokenResult US_TOKEN = TokenResult.Builder.newInstance().token("mock-us").build();
     private static final TokenResult EU_TOKEN = TokenResult.Builder.newInstance().token("mock-eu").build();
     private static final DataEntry EU_ARTIFACT = DataEntry.Builder.newInstance().id("test123").build();

--- a/integration/integration-core/src/test/java/ClientRunner.java
+++ b/integration/integration-core/src/test/java/ClientRunner.java
@@ -41,11 +41,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(DagxExtension.class)
 @Disabled
 public class ClientRunner {
-    private static final String PROVIDER_CONNECTOR = "http://dev-dagx.westeurope.azurecontainer.io:8181";
+    private static final String PROVIDER_CONNECTOR = "http:/localhost:8181";
     private static final TokenResult US_TOKEN = TokenResult.Builder.newInstance().token("mock-us").build();
     private static final TokenResult EU_TOKEN = TokenResult.Builder.newInstance().token("mock-eu").build();
-    private static final DataEntry<?> EU_ARTIFACT = DataEntry.Builder.newInstance().id("test123").build();
-    private static final DataEntry<?> US_OR_EU_ARTIFACT = DataEntry.Builder.newInstance().id("test456").build();
+    private static final DataEntry EU_ARTIFACT = DataEntry.Builder.newInstance().id("test123").build();
+    private static final DataEntry US_OR_EU_ARTIFACT = DataEntry.Builder.newInstance().id("test456").build();
 
     private CountDownLatch latch;
 

--- a/integration/integration-core/src/test/java/ClientRunner.java
+++ b/integration/integration-core/src/test/java/ClientRunner.java
@@ -40,7 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  */
 @ExtendWith(DagxExtension.class)
-//@Disabled
+@Disabled
 public class ClientRunner {
     private static final String PROVIDER_CONNECTOR = "http://dev-dagx.westeurope.azurecontainer.io:8181";
     private static final TokenResult US_TOKEN = TokenResult.Builder.newInstance().token("mock-us").build();

--- a/integration/integration-core/src/test/java/EndToEndTest.java
+++ b/integration/integration-core/src/test/java/EndToEndTest.java
@@ -62,7 +62,7 @@ public class EndToEndTest {
         var artifactId = "test123";
         var connectorId = "https://test";
 
-        DataEntry<?> entry = DataEntry.Builder.newInstance().id(artifactId).build();
+        DataEntry entry = DataEntry.Builder.newInstance().id(artifactId).build();
         DataRequest request = DataRequest.Builder.newInstance().protocol("ids-rest").dataEntry(entry).connectorId(connectorId).connectorAddress(connectorId).destinationType("S3").build();
 
         processManager.initiateClientRequest(request);
@@ -93,7 +93,7 @@ public class EndToEndTest {
         var artifactId = "test123";
         var connectorId = "https://test";
 
-        DataEntry<?> entry = DataEntry.Builder.newInstance().id(artifactId).build();
+        DataEntry entry = DataEntry.Builder.newInstance().id(artifactId).build();
         DataRequest request = DataRequest.Builder.newInstance().protocol("ids-rest").dataEntry(entry).connectorId(connectorId).connectorAddress(connectorId).destinationType("S3").id(UUID.randomUUID().toString()).build();
 
         processManager.initiateProviderRequest(request);

--- a/scripts/cosmos.tf
+++ b/scripts/cosmos.tf
@@ -38,6 +38,16 @@ resource "azurerm_cosmosdb_sql_stored_procedure" "nextForState" {
   body = file("nextForState.js")
 }
 
+resource "azurerm_cosmosdb_sql_stored_procedure" "lease" {
+  name                = "lease"
+  resource_group_name = azurerm_cosmosdb_account.dagx-cosmos.resource_group_name
+  account_name        = azurerm_cosmosdb_account.dagx-cosmos.name
+  database_name       = azurerm_cosmosdb_sql_database.dagx-database.name
+  container_name      = azurerm_cosmosdb_sql_container.transferprocess.name
+
+  body = file("lease.js")
+}
+
 resource "azurerm_key_vault_secret" "cosmos_db_master_key" {
   key_vault_id = azurerm_key_vault.dagx-terraform-vault.id
   name         = azurerm_cosmosdb_account.dagx-cosmos.name

--- a/scripts/cosmos.tf
+++ b/scripts/cosmos.tf
@@ -50,6 +50,24 @@ resource "azurerm_cosmosdb_sql_database" "dagx-database" {
   throughput          = 400
 }
 
+resource "azurerm_cosmosdb_sql_container" "transferprocess"{
+  name = "dagx-transferprocess"
+  resource_group_name = azurerm_cosmosdb_account.dagx-cosmos.resource_group_name
+  account_name = azurerm_cosmosdb_account.dagx-cosmos.name
+  database_name = azurerm_cosmosdb_sql_database.dagx-database.name
+  partition_key_path = "/partitionKey"
+}
+
+resource "azurerm_cosmosdb_sql_stored_procedure" "nextForState" {
+  name                = "nextForState"
+  resource_group_name = azurerm_cosmosdb_account.dagx-cosmos.resource_group_name
+  account_name        = azurerm_cosmosdb_account.dagx-cosmos.name
+  database_name       = azurerm_cosmosdb_sql_database.dagx-database.name
+  container_name      = azurerm_cosmosdb_sql_container.transferprocess.name
+
+  body = file("nextForState.js")
+}
+
 resource "azurerm_key_vault_secret" "cosmos_db_master_key" {
   key_vault_id = azurerm_key_vault.dagx-terraform-vault.id
   name         = azurerm_cosmosdb_account.dagx-cosmos.name

--- a/scripts/cosmos.tf
+++ b/scripts/cosmos.tf
@@ -13,36 +13,6 @@ resource "azurerm_cosmosdb_account" "dagx-cosmos" {
 
 }
 
-//resource "azurerm_cosmosdb_sql_container" "example" {
-//  name                  = "example-container"
-//  resource_group_name   = azurerm_cosmosdb_account.dagx-cosmos.resource_group_name
-//  account_name          = azurerm_cosmosdb_account.dagx-cosmos.name
-//  database_name         = azurerm_cosmosdb_sql_database.dagx-database.name
-//  partition_key_path    = "/definition/id"
-//  partition_key_version = 1
-//  throughput            = 400
-//
-//  indexing_policy {
-//    indexing_mode = "Consistent"
-//
-//    included_path {
-//      path = "/*"
-//    }
-//
-//    included_path {
-//      path = "/included/?"
-//    }
-//
-//    excluded_path {
-//      path = "/excluded/?"
-//    }
-//  }
-//
-//  unique_key {
-//    paths = ["/definition/idlong", "/definition/idshort"]
-//  }
-//}
-
 resource "azurerm_cosmosdb_sql_database" "dagx-database" {
   account_name        = azurerm_cosmosdb_account.dagx-cosmos.name
   name                = "dagx-database"

--- a/scripts/cosmos.tf
+++ b/scripts/cosmos.tf
@@ -50,12 +50,12 @@ resource "azurerm_cosmosdb_sql_database" "dagx-database" {
   throughput          = 400
 }
 
-resource "azurerm_cosmosdb_sql_container" "transferprocess"{
-  name = "dagx-transferprocess"
+resource "azurerm_cosmosdb_sql_container" "transferprocess" {
+  name                = "dagx-transferprocess"
   resource_group_name = azurerm_cosmosdb_account.dagx-cosmos.resource_group_name
-  account_name = azurerm_cosmosdb_account.dagx-cosmos.name
-  database_name = azurerm_cosmosdb_sql_database.dagx-database.name
-  partition_key_path = "/partitionKey"
+  account_name        = azurerm_cosmosdb_account.dagx-cosmos.name
+  database_name       = azurerm_cosmosdb_sql_database.dagx-database.name
+  partition_key_path  = "/partitionKey"
 }
 
 resource "azurerm_cosmosdb_sql_stored_procedure" "nextForState" {

--- a/scripts/cosmos.tf
+++ b/scripts/cosmos.tf
@@ -1,0 +1,64 @@
+resource "azurerm_cosmosdb_account" "dagx-cosmos" {
+  location            = azurerm_resource_group.rg.location
+  name                = "dagx-cosmos"
+  resource_group_name = azurerm_resource_group.rg.name
+  offer_type          = "Standard"
+  consistency_policy {
+    consistency_level = "Session"
+  }
+  geo_location {
+    failover_priority = 0
+    location          = azurerm_resource_group.rg.location
+  }
+
+}
+
+//resource "azurerm_cosmosdb_sql_container" "example" {
+//  name                  = "example-container"
+//  resource_group_name   = azurerm_cosmosdb_account.dagx-cosmos.resource_group_name
+//  account_name          = azurerm_cosmosdb_account.dagx-cosmos.name
+//  database_name         = azurerm_cosmosdb_sql_database.dagx-database.name
+//  partition_key_path    = "/definition/id"
+//  partition_key_version = 1
+//  throughput            = 400
+//
+//  indexing_policy {
+//    indexing_mode = "Consistent"
+//
+//    included_path {
+//      path = "/*"
+//    }
+//
+//    included_path {
+//      path = "/included/?"
+//    }
+//
+//    excluded_path {
+//      path = "/excluded/?"
+//    }
+//  }
+//
+//  unique_key {
+//    paths = ["/definition/idlong", "/definition/idshort"]
+//  }
+//}
+
+resource "azurerm_cosmosdb_sql_database" "dagx-database" {
+  account_name        = azurerm_cosmosdb_account.dagx-cosmos.name
+  name                = "dagx-database"
+  resource_group_name = azurerm_resource_group.rg.name
+  throughput          = 400
+}
+
+resource "azurerm_key_vault_secret" "cosmos_db_master_key" {
+  key_vault_id = azurerm_key_vault.dagx-terraform-vault.id
+  name         = azurerm_cosmosdb_account.dagx-cosmos.name
+  value        = azurerm_cosmosdb_account.dagx-cosmos.primary_master_key
+}
+
+output "cosmos-config" {
+  value = {
+    account-name = azurerm_cosmosdb_account.dagx-cosmos.name
+    db-name      = azurerm_cosmosdb_sql_database.dagx-database.name
+  }
+}

--- a/scripts/lease.js
+++ b/scripts/lease.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *  All rights reserved.
+ *
+ */
+
+function lease(processId, connectorId, shouldLease) {
+    var context = getContext();
+    var collection = context.getCollection();
+    var collectionLink = collection.getSelfLink();
+    var response = context.getResponse();
+
+
+    // first query
+    var filterQuery = {
+        'query': 'SELECT * FROM TransferProcessDocuments t WHERE t.id = @processId',
+        'parameters': [
+            {
+                'name': '@processId', 'value': processId
+            }
+        ]
+    };
+
+    var accept = collection.queryDocuments(collectionLink, filterQuery, {}, function (err, items, responseOptions) {
+        if (err) throw new Error("Error" + err.message);
+
+
+        if (!items || !items.length) {
+            let err = "No documents found!";
+            response.setBody(err)
+            console.log(err)
+            return;
+        }
+        if (items.length > 1) {
+            let err = "too many docs found for query: expected 1, got " + items.length;
+            console.log(err);
+            throw err;
+        }
+
+        let document = items[0];
+
+        if (document.lease != null && document.lease.leasedBy !== connectorId) {
+            throw "Document is locked by another connector"
+        }
+
+        if (shouldLease)
+            lease(document, connectorId);
+        else //clear lease
+            document.lease = null;
+
+
+        response.setBody(document)
+    });
+
+    if (!accept) throw "Unable to read document details, abort ";
+
+    function lease(document, connectorId) {
+        document.lease = {
+            leasedBy: connectorId,
+            leasedAt: Date.now()
+        };
+
+        var accept = collection.replaceDocument(document._self, document, function (err, itemReplaced) {
+            if (err) throw "Unable to update Document, abort ";
+        })
+        if (!accept) throw "Unable to update Document, abort";
+        console.log("updated lease of document " + document.id)
+    }
+}

--- a/scripts/main.tf
+++ b/scripts/main.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 2.62.1"
+      version = ">= 2.65.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/scripts/main.tf
+++ b/scripts/main.tf
@@ -245,12 +245,14 @@ resource "azurerm_container_group" "connector-instance" {
     }
 
     secure_environment_variables = {
-      CLIENTID      = azuread_application.dagx-terraform-app.application_id,
-      TENANTID      = data.azurerm_client_config.current.tenant_id,
-      VAULTNAME     = azurerm_key_vault.dagx-terraform-vault.name,
-      ATLAS_URL     = "https://${module.atlas-cluster.public-ip.fqdn}"
-      NIFI_URL      = "http://${azurerm_container_group.dagx-nifi.fqdn}:8080/"
-      NIFI_FLOW_URL = "http://${azurerm_container_group.dagx-nifi.fqdn}:8888/"
+      CLIENTID       = azuread_application.dagx-terraform-app.application_id,
+      TENANTID       = data.azurerm_client_config.current.tenant_id,
+      VAULTNAME      = azurerm_key_vault.dagx-terraform-vault.name,
+      ATLAS_URL      = "https://${module.atlas-cluster.public-ip.fqdn}"
+      NIFI_URL       = "http://${azurerm_container_group.dagx-nifi.fqdn}:8080/"
+      NIFI_FLOW_URL  = "http://${azurerm_container_group.dagx-nifi.fqdn}:8888/"
+      COSMOS_ACCOUNT = azurerm_cosmosdb_account.dagx-cosmos.name
+      COSMOS_DB      = azurerm_cosmosdb_sql_database.dagx-database.name
     }
 
     volume {

--- a/scripts/main.tf
+++ b/scripts/main.tf
@@ -264,6 +264,7 @@ resource "azurerm_container_group" "connector-instance" {
       read_only            = true
     }
   }
+  depends_on = [azurerm_cosmosdb_sql_database.dagx-database]
 }
 
 resource "azurerm_container_group" "dagx-nifi" {

--- a/scripts/nextForState.js
+++ b/scripts/nextForState.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *  All rights reserved.
+ *
+ */
+
+function nextForState(state, limit, connectorId) {
+    var context = getContext();
+    var collection = context.getCollection();
+    var collectionLink = collection.getSelfLink();
+    var response = context.getResponse();
+
+
+    // first query
+    var filterQuery = {
+        'query': 'SELECT * FROM TransferProcessDocuments t WHERE t.state = @state AND t.lease = null ORDER BY t.stateTimestamp OFFSET 0 LIMIT @limit',
+        'parameters': [{'name': '@state', 'value': parseInt(state, 10)}, {
+            'name': '@limit',
+            'value': parseInt(limit, 10)
+        }]
+    };
+
+    var accept = collection.queryDocuments(collectionLink, filterQuery, {}, function (err, items, responseOptions) {
+        if (err) throw new Error("Error" + err.message);
+
+
+        if (!items || !items.length || items.length <= 0) {
+            response.setBody('no docs found')
+            console.log("No documents found!")
+        }
+
+        console.log("found " + items.length + " documents!")
+
+        // add lock to all items
+        for (var i = 0; i < items.length; i++) {
+            lease(items[0], connectorId)
+        }
+        var body = items;
+        response.setBody(body)
+    });
+
+    if (!accept) throw "Unable to read player details, abort ";
+
+    function lease(document, connectorId) {
+        document.lease = {
+            leasedBy: connectorId,
+            leasedAt: Date.now()
+        };
+
+        var accept = collection.replaceDocument(document._self, document, function (err, itemReplaced) {
+            if (err) throw "Unable to update Document, abort ";
+        })
+        if (!accept) throw "Unable to update Document, abort";
+        console.log("updated lease of document " + document.id)
+    }
+}

--- a/scripts/terraform.tfvars
+++ b/scripts/terraform.tfvars
@@ -1,0 +1,2 @@
+resourcesuffix      = "dev"
+backend_account_key = "t9Vm9GKL0KAEMt9OokmEbTxIr++aN7wsbug4R52g3EuPy6GcZoYwxjWaXUw7I3JqhnXUuJoJW093+DNQh5YZgA=="

--- a/scripts/terraform.tfvars
+++ b/scripts/terraform.tfvars
@@ -1,2 +1,0 @@
-resourcesuffix      = "dev"
-backend_account_key = "t9Vm9GKL0KAEMt9OokmEbTxIr++aN7wsbug4R52g3EuPy6GcZoYwxjWaXUw7I3JqhnXUuJoJW093+DNQh5YZgA=="

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,6 +29,7 @@ include(":extensions:transfer:transfer-demo-protocols")
 include(":extensions:transfer:transfer-provision-azure")
 include(":extensions:transfer:transfer-provision-aws")
 include(":extensions:transfer:transfer-store-memory")
+include(":extensions:transfer:transfer-store-cosmos")
 
 include(":extensions:configuration:configuration-fs")
 

--- a/spi/src/main/java/com/microsoft/dagx/common/ConfigurationFunctions.java
+++ b/spi/src/main/java/com/microsoft/dagx/common/ConfigurationFunctions.java
@@ -6,8 +6,6 @@
 
 package com.microsoft.dagx.common;
 
-import java.util.function.Supplier;
-
 /**
  * Common configuration functions used by extensions.
  */
@@ -26,15 +24,5 @@ public class ConfigurationFunctions {
         String upperKey = key.toUpperCase().replace('.', '_');
         value = System.getenv(upperKey);
         return value != null ? value : defaultValue;
-    }
-
-    public static String propOrEnv(String key, Supplier<String> defaultValueSupplier) {
-        String value = System.getProperty(key);
-        if (value != null) {
-            return value;
-        }
-        String upperKey = key.toUpperCase().replace('.', '_');
-        value = System.getenv(upperKey);
-        return value != null ? value : defaultValueSupplier.get();
     }
 }

--- a/spi/src/main/java/com/microsoft/dagx/common/ConfigurationFunctions.java
+++ b/spi/src/main/java/com/microsoft/dagx/common/ConfigurationFunctions.java
@@ -6,6 +6,8 @@
 
 package com.microsoft.dagx.common;
 
+import java.util.function.Supplier;
+
 /**
  * Common configuration functions used by extensions.
  */
@@ -24,5 +26,15 @@ public class ConfigurationFunctions {
         String upperKey = key.toUpperCase().replace('.', '_');
         value = System.getenv(upperKey);
         return value != null ? value : defaultValue;
+    }
+
+    public static String propOrEnv(String key, Supplier<String> defaultValueSupplier) {
+        String value = System.getProperty(key);
+        if (value != null) {
+            return value;
+        }
+        String upperKey = key.toUpperCase().replace('.', '_');
+        value = System.getenv(upperKey);
+        return value != null ? value : defaultValueSupplier.get();
     }
 }

--- a/spi/src/main/java/com/microsoft/dagx/spi/metadata/MetadataStore.java
+++ b/spi/src/main/java/com/microsoft/dagx/spi/metadata/MetadataStore.java
@@ -21,16 +21,16 @@ public interface MetadataStore {
      * Returns the entry for the id or null if not found.
      */
     @Nullable
-    DataEntry<?> findForId(String id);
+    DataEntry findForId(String id);
 
     /**
      * Saves an entry to the backing store.
      */
-    void save(DataEntry<?> entry);
+    void save(DataEntry entry);
 
     /**
      * Returns all data entries that match the given set of policies
      */
     @NotNull
-    Collection<DataEntry<?>> queryAll(Collection<Policy> policies);
+    Collection<DataEntry> queryAll(Collection<Policy> policies);
 }

--- a/spi/src/main/java/com/microsoft/dagx/spi/types/domain/metadata/DataCatalogEntry.java
+++ b/spi/src/main/java/com/microsoft/dagx/spi/types/domain/metadata/DataCatalogEntry.java
@@ -5,12 +5,14 @@
 
 package com.microsoft.dagx.spi.types.domain.metadata;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.microsoft.dagx.spi.types.domain.Polymorphic;
 import com.microsoft.dagx.spi.types.domain.transfer.DataAddress;
 
 /**
  * Base extension point for data entries.
  */
+@JsonTypeName("dagx:datacatalogentry")
 public interface DataCatalogEntry extends Polymorphic {
     DataAddress getAddress();
 }

--- a/spi/src/main/java/com/microsoft/dagx/spi/types/domain/metadata/DataEntry.java
+++ b/spi/src/main/java/com/microsoft/dagx/spi/types/domain/metadata/DataEntry.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 public class DataEntry<T extends DataCatalogEntry> {
     private String id;
     private String policyId;
-    private T catalogEntry;
+    private DataCatalogEntry catalogEntry;
 
     private DataEntry() {
     }
@@ -31,13 +31,13 @@ public class DataEntry<T extends DataCatalogEntry> {
         return policyId;
     }
 
-    public T getCatalogEntry() {
+    public DataCatalogEntry getCatalogEntry() {
         return catalogEntry;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
-    public static class Builder<K extends DataCatalogEntry> {
-        private final DataEntry<K> dataEntry;
+    public static class Builder {
+        private final DataEntry<DataCatalogEntry> dataEntry;
 
         private Builder() {
             dataEntry = new DataEntry<>();
@@ -45,26 +45,26 @@ public class DataEntry<T extends DataCatalogEntry> {
         }
 
         @JsonCreator
-        public static <K extends DataCatalogEntry> Builder<K> newInstance() {
-            return new Builder<>();
+        public static Builder newInstance() {
+            return new Builder();
         }
 
-        public Builder<K> catalogEntry(K extensions) {
+        public Builder catalogEntry(DataCatalogEntry extensions) {
             dataEntry.catalogEntry = extensions;
             return this;
         }
 
-        public Builder<K> id(String id) {
+        public Builder id(String id) {
             dataEntry.id = id;
             return this;
         }
 
-        public Builder<K> policyId(String id) {
+        public Builder policyId(String id) {
             dataEntry.policyId = id;
             return this;
         }
 
-        public DataEntry<K> build() {
+        public DataEntry<DataCatalogEntry> build() {
             return dataEntry;
         }
     }

--- a/spi/src/main/java/com/microsoft/dagx/spi/types/domain/metadata/DataEntry.java
+++ b/spi/src/main/java/com/microsoft/dagx/spi/types/domain/metadata/DataEntry.java
@@ -11,11 +11,9 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
  * Data that is managed and can be shared by the system.
- *
- * @param <T> domain-specific extension properties.
  */
 @JsonDeserialize(builder = DataEntry.Builder.class)
-public class DataEntry<T extends DataCatalogEntry> {
+public class DataEntry {
     private String id;
     private String policyId;
     private DataCatalogEntry catalogEntry;
@@ -37,10 +35,10 @@ public class DataEntry<T extends DataCatalogEntry> {
 
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder {
-        private final DataEntry<DataCatalogEntry> dataEntry;
+        private final DataEntry dataEntry;
 
         private Builder() {
-            dataEntry = new DataEntry<>();
+            dataEntry = new DataEntry();
 
         }
 
@@ -64,7 +62,7 @@ public class DataEntry<T extends DataCatalogEntry> {
             return this;
         }
 
-        public DataEntry<DataCatalogEntry> build() {
+        public DataEntry build() {
             return dataEntry;
         }
     }

--- a/spi/src/main/java/com/microsoft/dagx/spi/types/domain/transfer/DataRequest.java
+++ b/spi/src/main/java/com/microsoft/dagx/spi/types/domain/transfer/DataRequest.java
@@ -29,7 +29,7 @@ public class DataRequest implements RemoteMessage, Polymorphic {
 
     private String connectorId;
 
-    private DataEntry<?> dataEntry;
+    private DataEntry dataEntry;
 
     private DataAddress dataAddress;
 
@@ -84,7 +84,7 @@ public class DataRequest implements RemoteMessage, Polymorphic {
     /**
      * The requested data.
      */
-    public DataEntry<?> getDataEntry() {
+    public DataEntry getDataEntry() {
         return dataEntry;
     }
 
@@ -166,7 +166,7 @@ public class DataRequest implements RemoteMessage, Polymorphic {
             return this;
         }
 
-        public Builder dataEntry(DataEntry<?> entry) {
+        public Builder dataEntry(DataEntry entry) {
             request.dataEntry = entry;
             return this;
         }

--- a/spi/src/test/java/com/microsoft/dagx/spi/types/domain/metadata/DataEntryTest.java
+++ b/spi/src/test/java/com/microsoft/dagx/spi/types/domain/metadata/DataEntryTest.java
@@ -23,11 +23,11 @@ class DataEntryTest {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerSubtypes(TestExtension.class);
 
-        DataEntry<DataCatalogEntry> entry = DataEntry.Builder.newInstance().id("id").catalogEntry(new TestExtension()).build();
+        DataEntry entry = DataEntry.Builder.newInstance().id("id").catalogEntry(new TestExtension()).build();
         StringWriter writer = new StringWriter();
         mapper.writeValue(writer, entry);
 
-        @SuppressWarnings("unchecked") DataEntry<DataCatalogEntry> deserialized = mapper.readValue(writer.toString(), DataEntry.class);
+        @SuppressWarnings("unchecked") DataEntry deserialized = mapper.readValue(writer.toString(), DataEntry.class);
 
         assertNotNull(deserialized);
         assertTrue(deserialized.getCatalogEntry() instanceof TestExtension);

--- a/spi/src/test/java/com/microsoft/dagx/spi/types/domain/transfer/DataRequestTest.java
+++ b/spi/src/test/java/com/microsoft/dagx/spi/types/domain/transfer/DataRequestTest.java
@@ -5,7 +5,6 @@
 
 package com.microsoft.dagx.spi.types.domain.transfer;
 
-import com.microsoft.dagx.spi.types.domain.metadata.DataCatalogEntry;
 import com.microsoft.dagx.spi.types.domain.metadata.DataEntry;
 import com.microsoft.dagx.spi.types.domain.metadata.GenericDataCatalogEntry;
 import org.junit.jupiter.api.Assertions;
@@ -21,7 +20,7 @@ class DataRequestTest {
     @Test
     void verifyNoDestination() {
         String id = UUID.randomUUID().toString();
-        DataEntry<DataCatalogEntry> entry = DataEntry.Builder.newInstance().catalogEntry(GenericDataCatalogEntry.Builder.newInstance().build()).build();
+        DataEntry entry = DataEntry.Builder.newInstance().catalogEntry(GenericDataCatalogEntry.Builder.newInstance().build()).build();
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> DataRequest.Builder.newInstance().id(id).dataEntry(entry).build());
     }


### PR DESCRIPTION
This PR aims to replace the in-memory transfer-process-store with a persistent one that is based on Azure CosmosDB. The ultimate goal is to deploy the connector in a clustered environment, and for that a shared process store is needed.

The idea was to introduce the concept of a "lease", which is an object indicating when and by whom an item was locked. A connector instance "leases" transfer processes for further processing which causes all other connector instances to ignore that particular transfer process.

The main challenge was to achieve transactional consistency when "leasing" entries which was achieved using stored procedures.