### PR TITLE
added event sourcing and forwarding to Azure Event Grid

### DIFF
--- a/core/src/main/java/com/microsoft/dagx/system/DefaultServiceExtensionContext.java
+++ b/core/src/main/java/com/microsoft/dagx/system/DefaultServiceExtensionContext.java
@@ -99,6 +99,15 @@ public class DefaultServiceExtensionContext implements ServiceExtensionContext {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getService(Class<T> type, boolean isOptional) {
+        if (!isOptional) {
+            return getService(type);
+        }
+        return (T) services.get(type);
+    }
+
+    @Override
     public <T> void registerService(Class<T> type, T service) {
         services.put(type, service);
     }

--- a/distributions/demo-e2e/Dockerfile
+++ b/distributions/demo-e2e/Dockerfile
@@ -17,4 +17,6 @@ ENTRYPOINT java \
     -Ddagx.nifi.flow.url=${NIFI_FLOW_URL} \
     -Ddagx.cosmos.account.name=${COSMOS_ACCOUNT} \
     -Ddagx.cosmos.database.name=${COSMOS_DB} \
+    -Ddagx.events.topic.name=connector-events \
+    -Ddagx.events.topic.endpoint=https://connector-events.westeurope-1.eventgrid.azure.net/api/events \
     -Djava.security.edg=file:/dev/.urandom -jar dagx-demo-e2e.jar

--- a/distributions/demo-e2e/Dockerfile
+++ b/distributions/demo-e2e/Dockerfile
@@ -17,6 +17,6 @@ ENTRYPOINT java \
     -Ddagx.nifi.flow.url=${NIFI_FLOW_URL} \
     -Ddagx.cosmos.account.name=${COSMOS_ACCOUNT} \
     -Ddagx.cosmos.database.name=${COSMOS_DB} \
-    -Ddagx.events.topic.name=connector-events \
-    -Ddagx.events.topic.endpoint=https://connector-events.westeurope-1.eventgrid.azure.net/api/events \
+    -Ddagx.events.topic.name=${TOPIC_NAME} \
+    -Ddagx.events.topic.endpoint=${TOPIC_ENDPOINT} \
     -Djava.security.edg=file:/dev/.urandom -jar dagx-demo-e2e.jar

--- a/distributions/demo-e2e/build.gradle.kts
+++ b/distributions/demo-e2e/build.gradle.kts
@@ -22,9 +22,10 @@ dependencies {
     implementation(project(":extensions:transfer:transfer-provision-azure"))
     implementation(project(":extensions:transfer:transfer-nifi"))
 
+    implementation(project(":extensions:events:events-azure"))
+
     implementation(project(":extensions:ids"))
 
-    // todo: replace with atlas - but we need this for the time being to provide catalog entries
     implementation(project(":extensions:catalog:catalog-atlas"))
     implementation(project(":extensions:dataseed"))
 

--- a/extensions/catalog/catalog-atlas/src/main/java/com/microsoft/dagx/catalog/atlas/metadata/AtlasMetadataStore.java
+++ b/extensions/catalog/catalog-atlas/src/main/java/com/microsoft/dagx/catalog/atlas/metadata/AtlasMetadataStore.java
@@ -14,6 +14,8 @@ import com.microsoft.dagx.policy.model.Policy;
 import com.microsoft.dagx.schema.DataSchema;
 import com.microsoft.dagx.schema.SchemaRegistry;
 import com.microsoft.dagx.spi.DagxException;
+import com.microsoft.dagx.spi.metadata.MetadataListener;
+import com.microsoft.dagx.spi.metadata.MetadataObservable;
 import com.microsoft.dagx.spi.metadata.MetadataStore;
 import com.microsoft.dagx.spi.monitor.Monitor;
 import com.microsoft.dagx.spi.types.domain.metadata.DataEntry;
@@ -30,7 +32,7 @@ import java.util.stream.Collectors;
 import static java.util.stream.Collectors.toSet;
 
 @SuppressWarnings("unchecked")
-public class AtlasMetadataStore implements MetadataStore {
+public class AtlasMetadataStore extends MetadataObservable implements MetadataStore {
     private static final String ATLAS_PROPERTY_KEYNAME = "keyName";
     private static final String ATLAS_PROPERTY_TYPE = "type";
     private final AtlasApi atlasApi;
@@ -46,7 +48,7 @@ public class AtlasMetadataStore implements MetadataStore {
 
     @Override
     public @Nullable DataEntry findForId(String id) {
-
+        getListeners().forEach(MetadataListener::searchInitiated);
         var properties = atlasApi.getEntityById(id);
 
         if (properties == null) {
@@ -101,11 +103,13 @@ public class AtlasMetadataStore implements MetadataStore {
 
     @Override
     public void save(DataEntry entry) {
+        getListeners().forEach(MetadataListener::metadataItemAdded);
         monitor.severe("Save not yet implemented");
     }
 
     @Override
     public @NotNull Collection<DataEntry> queryAll(Collection<Policy> policies) {
+        getListeners().forEach(MetadataListener::querySubmitted);
         if (policies.isEmpty()) {
             return Collections.emptyList();
         }

--- a/extensions/events/events-azure/build.gradle.kts
+++ b/extensions/events/events-azure/build.gradle.kts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * All rights reserved.
+ */
+
+plugins {
+    `java-library`
+}
+
+val eventGridSdkVersion: String by project
+
+dependencies {
+    api(project(":spi"))
+    implementation(project(":extensions:schema"))
+    implementation("com.azure:azure-messaging-eventgrid:${eventGridSdkVersion}")
+}
+
+

--- a/extensions/events/events-azure/src/main/java/com/microsoft/dagx/events/azure/AzureEventExtension.java
+++ b/extensions/events/events-azure/src/main/java/com/microsoft/dagx/events/azure/AzureEventExtension.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *  All rights reserved.
+ *
+ */
+package com.microsoft.dagx.events.azure;
+
+import com.azure.core.credential.AzureKeyCredential;
+import com.azure.messaging.eventgrid.EventGridPublisherClientBuilder;
+import com.microsoft.dagx.spi.metadata.MetadataObservable;
+import com.microsoft.dagx.spi.monitor.Monitor;
+import com.microsoft.dagx.spi.security.Vault;
+import com.microsoft.dagx.spi.system.ServiceExtension;
+import com.microsoft.dagx.spi.system.ServiceExtensionContext;
+import com.microsoft.dagx.spi.transfer.TransferProcessObservable;
+
+import java.util.Objects;
+import java.util.Set;
+
+public class AzureEventExtension implements ServiceExtension {
+
+
+    private static final String TOPIC_NAME_SETTING = "dagx.events.topic.name";
+    private static final String TOPIC_ENDPOINT_SETTING = "dagx.events.topic.endpoint";
+    private Monitor monitor;
+
+    @Override
+    public Set<String> requires() {
+        return Set.of("dagx:transfer-process-observable");
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        monitor = context.getMonitor();
+
+        monitor.info("AzureEventsExtension: create event grid appender");
+        registerListeners(context);
+
+        monitor.info("Initialized Azure Events Extension");
+    }
+
+
+    @Override
+    public void start() {
+        monitor.info("Started Azure Events Extension");
+    }
+
+    @Override
+    public void shutdown() {
+        monitor.info("Shutdown Azure Events Extension");
+    }
+
+    private void registerListeners(ServiceExtensionContext context) {
+
+        var vault = context.getService(Vault.class);
+        var endpoint = context.getSetting(TOPIC_ENDPOINT_SETTING, null);
+        var topicName = context.getSetting(TOPIC_NAME_SETTING, null);
+        var publisherClient = new EventGridPublisherClientBuilder()
+                .credential(new AzureKeyCredential(Objects.requireNonNull(vault.resolveSecret(topicName), "Did not find secret in vault: " + endpoint)))
+                .endpoint(endpoint)
+                .buildEventGridEventPublisherAsyncClient();
+
+        final EventGridPublisher publisher = new EventGridPublisher(monitor, publisherClient);
+
+        var processObservable = context.getService(TransferProcessObservable.class, true);
+        if (processObservable != null) {
+            processObservable.registerListener(publisher);
+        }
+
+        var metadataObservable = context.getService(MetadataObservable.class, true);
+        if (metadataObservable != null) {
+            metadataObservable.registerListener(publisher);
+        }
+
+
+    }
+}

--- a/extensions/events/events-azure/src/main/java/com/microsoft/dagx/events/azure/AzureEventExtension.java
+++ b/extensions/events/events-azure/src/main/java/com/microsoft/dagx/events/azure/AzureEventExtension.java
@@ -64,7 +64,7 @@ public class AzureEventExtension implements ServiceExtension {
                 .endpoint(endpoint)
                 .buildEventGridEventPublisherAsyncClient();
 
-        final EventGridPublisher publisher = new EventGridPublisher(monitor, publisherClient);
+        final AzureEventGridPublisher publisher = new AzureEventGridPublisher(monitor, publisherClient);
 
         var processObservable = context.getService(TransferProcessObservable.class, true);
         if (processObservable != null) {

--- a/extensions/events/events-azure/src/main/java/com/microsoft/dagx/events/azure/AzureEventGridPublisher.java
+++ b/extensions/events/events-azure/src/main/java/com/microsoft/dagx/events/azure/AzureEventGridPublisher.java
@@ -13,73 +13,75 @@ import com.microsoft.dagx.spi.metadata.MetadataListener;
 import com.microsoft.dagx.spi.monitor.Monitor;
 import com.microsoft.dagx.spi.transfer.TransferProcessListener;
 import com.microsoft.dagx.spi.types.domain.transfer.TransferProcess;
+import com.microsoft.dagx.spi.types.domain.transfer.TransferProcessStates;
 import org.jetbrains.annotations.NotNull;
 import reactor.core.publisher.BaseSubscriber;
 import reactor.core.publisher.Mono;
 
-class EventGridPublisher implements TransferProcessListener, MetadataListener {
+class AzureEventGridPublisher implements TransferProcessListener, MetadataListener {
 
     private final Monitor monitor;
     private final EventGridPublisherAsyncClient<EventGridEvent> client;
     private final String eventTypeTransferprocess = "dagx/transfer/transferprocess";
     private final String eventTypeMetadata = "dagx/metadata/store";
 
-    public EventGridPublisher(Monitor monitor, EventGridPublisherAsyncClient<EventGridEvent> client) {
+    public AzureEventGridPublisher(Monitor monitor, EventGridPublisherAsyncClient<EventGridEvent> client) {
         this.monitor = monitor;
         this.client = client;
     }
 
     @Override
     public void created(TransferProcess process) {
+        var dto = createDto(process);
         if (process.getType() == TransferProcess.Type.CLIENT) {
-            sendEvent("createdClient", eventTypeTransferprocess, process).subscribe(new DefaultSubscriber<>("Transfer process created"));
+            sendEvent("createdClient", eventTypeTransferprocess, dto).subscribe(new LoggingSubscriber<>("Transfer process created"));
         } else {
-            sendEvent("createdProvider", eventTypeTransferprocess, process).subscribe(new DefaultSubscriber<>("Transfer process created"));
+            sendEvent("createdProvider", eventTypeTransferprocess, dto).subscribe(new LoggingSubscriber<>("Transfer process created"));
         }
     }
 
     @Override
     public void completed(TransferProcess process) {
-        sendEvent("completed", eventTypeTransferprocess, process).subscribe(new DefaultSubscriber<>("Transfer process completed"));
+        sendEvent("completed", eventTypeTransferprocess, createDto(process)).subscribe(new LoggingSubscriber<>("Transfer process completed"));
     }
 
 
     @Override
     public void deprovisioned(TransferProcess process) {
-        sendEvent("deprovisioned", eventTypeTransferprocess, process).subscribe(new DefaultSubscriber<>("Transfer process resources deprovisioned"));
+        sendEvent("deprovisioned", eventTypeTransferprocess, createDto(process)).subscribe(new LoggingSubscriber<>("Transfer process resources deprovisioned"));
 
     }
 
     @Override
     public void ended(TransferProcess process) {
-        sendEvent("ended", eventTypeTransferprocess, process).subscribe(new DefaultSubscriber<>("Transfer process ended"));
+        sendEvent("ended", eventTypeTransferprocess, createDto(process)).subscribe(new LoggingSubscriber<>("Transfer process ended"));
 
     }
 
     @Override
     public void error(TransferProcess process) {
-        sendEvent("error", eventTypeTransferprocess, process).subscribe(new DefaultSubscriber<>("Transfer process errored!"));
+        sendEvent("error", eventTypeTransferprocess, createDto(process)).subscribe(new LoggingSubscriber<>("Transfer process errored!"));
 
     }
 
     @Override
     public void querySubmitted() {
-        sendEvent("querySubmitted", eventTypeMetadata, null).subscribe(new DefaultSubscriber<>("query submitted"));
+        sendEvent("querySubmitted", eventTypeMetadata, null).subscribe(new LoggingSubscriber<>("query submitted"));
     }
 
     @Override
     public void searchInitiated() {
-        sendEvent("searchInitiated", eventTypeMetadata, null).subscribe(new DefaultSubscriber<>("search initiated"));
+        sendEvent("searchInitiated", eventTypeMetadata, null).subscribe(new LoggingSubscriber<>("search initiated"));
     }
 
     @Override
     public void metadataItemAdded() {
-        sendEvent("itemAdded", eventTypeMetadata, null).subscribe(new DefaultSubscriber<>("AzureEventGrid: metadata item added"));
+        sendEvent("itemAdded", eventTypeMetadata, null).subscribe(new LoggingSubscriber<>("AzureEventGrid: metadata item added"));
     }
 
     @Override
     public void metadataItemUpdated() {
-        sendEvent("itemUpdated", eventTypeMetadata, null).subscribe(new DefaultSubscriber<>("metadata item updated"));
+        sendEvent("itemUpdated", eventTypeMetadata, null).subscribe(new LoggingSubscriber<>("metadata item updated"));
     }
 
     private Mono<Void> sendEvent(String what, String where, Object payload) {
@@ -88,11 +90,20 @@ class EventGridPublisher implements TransferProcessListener, MetadataListener {
         return client.sendEvent(evt);
     }
 
-    private class DefaultSubscriber<T> extends BaseSubscriber<T> {
+    @NotNull
+    private TransferProcessDto createDto(TransferProcess process) {
+        return TransferProcessDto.Builder.newInstance()
+                .state(TransferProcessStates.from(process.getState()))
+                .requestId(process.getDataRequest().getId())
+                .type(process.getType())
+                .build();
+    }
+
+    private class LoggingSubscriber<T> extends BaseSubscriber<T> {
 
         private final String message;
 
-        DefaultSubscriber(String message) {
+        LoggingSubscriber(String message) {
             this.message = message;
         }
 

--- a/extensions/events/events-azure/src/main/java/com/microsoft/dagx/events/azure/EventGridPublisher.java
+++ b/extensions/events/events-azure/src/main/java/com/microsoft/dagx/events/azure/EventGridPublisher.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *  All rights reserved.
+ *
+ */
+
+package com.microsoft.dagx.events.azure;
+
+import com.azure.core.util.BinaryData;
+import com.azure.messaging.eventgrid.EventGridEvent;
+import com.azure.messaging.eventgrid.EventGridPublisherAsyncClient;
+import com.microsoft.dagx.spi.metadata.MetadataListener;
+import com.microsoft.dagx.spi.monitor.Monitor;
+import com.microsoft.dagx.spi.transfer.TransferProcessListener;
+import com.microsoft.dagx.spi.types.domain.transfer.TransferProcess;
+import org.jetbrains.annotations.NotNull;
+import reactor.core.publisher.BaseSubscriber;
+import reactor.core.publisher.Mono;
+
+class EventGridPublisher implements TransferProcessListener, MetadataListener {
+
+    private final Monitor monitor;
+    private final EventGridPublisherAsyncClient<EventGridEvent> client;
+    private final String eventTypeTransferprocess = "dagx/transfer/transferprocess";
+    private final String eventTypeMetadata = "dagx/metadata/store";
+
+    public EventGridPublisher(Monitor monitor, EventGridPublisherAsyncClient<EventGridEvent> client) {
+        this.monitor = monitor;
+        this.client = client;
+    }
+
+    @Override
+    public void created(TransferProcess process) {
+        if (process.getType() == TransferProcess.Type.CLIENT) {
+            sendEvent("createdClient", eventTypeTransferprocess, process).subscribe(new DefaultSubscriber<>("Transfer process created"));
+        } else {
+            sendEvent("createdProvider", eventTypeTransferprocess, process).subscribe(new DefaultSubscriber<>("Transfer process created"));
+        }
+    }
+
+    @Override
+    public void completed(TransferProcess process) {
+        sendEvent("completed", eventTypeTransferprocess, process).subscribe(new DefaultSubscriber<>("Transfer process completed"));
+    }
+
+
+    @Override
+    public void deprovisioned(TransferProcess process) {
+        sendEvent("deprovisioned", eventTypeTransferprocess, process).subscribe(new DefaultSubscriber<>("Transfer process resources deprovisioned"));
+
+    }
+
+    @Override
+    public void ended(TransferProcess process) {
+        sendEvent("ended", eventTypeTransferprocess, process).subscribe(new DefaultSubscriber<>("Transfer process ended"));
+
+    }
+
+    @Override
+    public void error(TransferProcess process) {
+        sendEvent("error", eventTypeTransferprocess, process).subscribe(new DefaultSubscriber<>("Transfer process errored!"));
+
+    }
+
+    @Override
+    public void querySubmitted() {
+        sendEvent("querySubmitted", eventTypeMetadata, null).subscribe(new DefaultSubscriber<>("query submitted"));
+    }
+
+    @Override
+    public void searchInitiated() {
+        sendEvent("searchInitiated", eventTypeMetadata, null).subscribe(new DefaultSubscriber<>("search initiated"));
+    }
+
+    @Override
+    public void metadataItemAdded() {
+        sendEvent("itemAdded", eventTypeMetadata, null).subscribe(new DefaultSubscriber<>("AzureEventGrid: metadata item added"));
+    }
+
+    @Override
+    public void metadataItemUpdated() {
+        sendEvent("itemUpdated", eventTypeMetadata, null).subscribe(new DefaultSubscriber<>("metadata item updated"));
+    }
+
+    private Mono<Void> sendEvent(String what, String where, Object payload) {
+        final BinaryData data = BinaryData.fromObject(payload);
+        var evt = new EventGridEvent(what, where, data, "0.1");
+        return client.sendEvent(evt);
+    }
+
+    private class DefaultSubscriber<T> extends BaseSubscriber<T> {
+
+        private final String message;
+
+        DefaultSubscriber(String message) {
+            this.message = message;
+        }
+
+        @Override
+        protected void hookOnComplete() {
+            monitor.info("AzureEventGrid: " + message);
+        }
+
+        @Override
+        protected void hookOnError(@NotNull Throwable throwable) {
+            monitor.severe("Error during event publishing", throwable);
+        }
+    }
+}

--- a/extensions/events/events-azure/src/main/java/com/microsoft/dagx/events/azure/TransferProcessDto.java
+++ b/extensions/events/events-azure/src/main/java/com/microsoft/dagx/events/azure/TransferProcessDto.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *  All rights reserved.
+ *
+ */
+
+package com.microsoft.dagx.events.azure;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.microsoft.dagx.spi.types.domain.transfer.TransferProcess;
+import com.microsoft.dagx.spi.types.domain.transfer.TransferProcessStates;
+
+/**
+ * Data transfer object for {@link TransferProcess} instances.
+ * Generally, we should aim to give out as little information as is necessary, e.g. external apps might not need no know
+ * the "stateCount" property of a TP. In other instance we simply cannot give internal information, such as the transferprocess id, out for
+ * reasons of security.
+ */
+@JsonDeserialize(builder = TransferProcessDto.Builder.class)
+public class TransferProcessDto {
+    private String requestId;
+    private TransferProcess.Type type;
+    private String state;
+    private int stateCode;
+
+    private TransferProcessDto() {
+
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public TransferProcess.Type getType() {
+        return type;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public int getStateCode() {
+        return stateCode;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder {
+        private String requestId;
+        private TransferProcess.Type type;
+        private String state;
+        private int stateCode;
+
+        private Builder() {
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder requestId(String requestId) {
+            this.requestId = requestId;
+            return this;
+        }
+
+        public Builder type(TransferProcess.Type type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder state(TransferProcessStates state) {
+            this.state = state.toString();
+            stateCode = state.code();
+            return this;
+        }
+
+
+        public TransferProcessDto build() {
+            TransferProcessDto transferProcessDto = new TransferProcessDto();
+            transferProcessDto.state = state;
+            transferProcessDto.type = type;
+            transferProcessDto.requestId = requestId;
+            transferProcessDto.stateCode = stateCode;
+            return transferProcessDto;
+        }
+    }
+}

--- a/extensions/events/events-azure/src/main/resources/META-INF/services/com.microsoft.dagx.spi.system.ServiceExtension
+++ b/extensions/events/events-azure/src/main/resources/META-INF/services/com.microsoft.dagx.spi.system.ServiceExtension
@@ -1,0 +1,1 @@
+com.microsoft.dagx.events.azure.AzureEventExtension

--- a/extensions/metadata/metadata-memory/src/main/java/com/microsoft/dagx/metadata/memory/InMemoryMetadataStore.java
+++ b/extensions/metadata/metadata-memory/src/main/java/com/microsoft/dagx/metadata/memory/InMemoryMetadataStore.java
@@ -7,6 +7,8 @@ package com.microsoft.dagx.metadata.memory;
 
 import com.microsoft.dagx.policy.model.Identifiable;
 import com.microsoft.dagx.policy.model.Policy;
+import com.microsoft.dagx.spi.metadata.MetadataListener;
+import com.microsoft.dagx.spi.metadata.MetadataObservable;
 import com.microsoft.dagx.spi.metadata.MetadataStore;
 import com.microsoft.dagx.spi.types.domain.metadata.DataEntry;
 import org.jetbrains.annotations.NotNull;
@@ -23,21 +25,28 @@ import static java.util.stream.Collectors.toSet;
 /**
  * An ephemeral metadata store.
  */
-public class InMemoryMetadataStore implements MetadataStore {
+public class InMemoryMetadataStore extends MetadataObservable implements MetadataStore {
     private final Map<String, DataEntry> cache = new ConcurrentHashMap<>();
 
     @Override
     public @Nullable DataEntry findForId(String id) {
+        getListeners().forEach(MetadataListener::searchInitiated);
         return cache.get(id);
     }
 
     @Override
     public void save(DataEntry entry) {
+        if (cache.containsKey(entry.getId())) {
+            getListeners().forEach(MetadataListener::metadataItemUpdated);
+        } else {
+            getListeners().forEach(MetadataListener::metadataItemAdded);
+        }
         cache.put(entry.getId(), entry);
     }
 
     @Override
     public @NotNull Collection<DataEntry> queryAll(Collection<Policy> policies) {
+        getListeners().forEach(MetadataListener::querySubmitted);
         Set<String> policyIds = policies.stream().map(Identifiable::getUid).collect(toSet());
         return cache.values().stream().filter(entry -> policyIds.contains(entry.getPolicyId())).collect(Collectors.toList());
     }

--- a/extensions/metadata/metadata-memory/src/main/java/com/microsoft/dagx/metadata/memory/InMemoryServiceExtension.java
+++ b/extensions/metadata/metadata-memory/src/main/java/com/microsoft/dagx/metadata/memory/InMemoryServiceExtension.java
@@ -5,10 +5,13 @@
 
 package com.microsoft.dagx.metadata.memory;
 
+import com.microsoft.dagx.spi.metadata.MetadataObservable;
 import com.microsoft.dagx.spi.metadata.MetadataStore;
 import com.microsoft.dagx.spi.monitor.Monitor;
 import com.microsoft.dagx.spi.system.ServiceExtension;
 import com.microsoft.dagx.spi.system.ServiceExtensionContext;
+
+import java.util.Set;
 
 public class InMemoryServiceExtension implements ServiceExtension {
     private Monitor monitor;
@@ -19,10 +22,17 @@ public class InMemoryServiceExtension implements ServiceExtension {
     }
 
     @Override
+    public Set<String> provides() {
+        return Set.of("dagx:metadata-store-observable");
+    }
+
+    @Override
     public void initialize(ServiceExtensionContext context) {
         monitor = context.getMonitor();
 
-        context.registerService(MetadataStore.class, new InMemoryMetadataStore());
+        final InMemoryMetadataStore service = new InMemoryMetadataStore();
+        context.registerService(MetadataStore.class, service);
+        context.registerService(MetadataObservable.class, service);
 
         monitor.info("Initialized In-Memory Metadata extension");
     }

--- a/extensions/transfer/transfer-core/src/main/java/com/microsoft/dagx/transfer/core/CoreTransferExtension.java
+++ b/extensions/transfer/transfer-core/src/main/java/com/microsoft/dagx/transfer/core/CoreTransferExtension.java
@@ -92,7 +92,7 @@ public class CoreTransferExtension implements ServiceExtension {
 
     @Override
     public Set<String> provides() {
-        return Set.of("dagx:statuschecker", "dagx:dispatcher", "dagx:manifestgenerator");
+        return Set.of("dagx:statuschecker", "dagx:dispatcher", "dagx:manifestgenerator", "dagx:transfer-process-manager", "dagx:transfer-process-observable");
     }
 
     @Override

--- a/extensions/transfer/transfer-core/src/test/java/com/microsoft/dagx/transfer/core/transfer/TransferProcessManagerImplTest.java
+++ b/extensions/transfer/transfer-core/src/test/java/com/microsoft/dagx/transfer/core/transfer/TransferProcessManagerImplTest.java
@@ -78,56 +78,50 @@ class TransferProcessManagerImplTest {
     @Test
     void registerListener() {
         var listener = new TestListener();
-        manager.registerListener("test-process", listener);
+        manager.registerListener(listener);
 
-        assertThat(manager.getListeners()).containsKey("test-process");
-        assertThat(manager.getListeners().get("test-process")).containsOnly(listener);
+        assertThat(manager.getListeners()).containsOnly(listener);
     }
 
     @Test
     void registerListener_processIdExists_shouldAdd() {
         var listener = new TestListener();
         var listener2 = new TestListener();
-        manager.registerListener("test-process", listener);
-        manager.registerListener("test-process", listener2);
+        manager.registerListener(listener);
+        manager.registerListener(listener2);
 
-        assertThat(manager.getListeners()).containsKey("test-process");
-        assertThat(manager.getListeners().get("test-process")).hasSize(2).containsOnly(listener, listener2);
+        assertThat(manager.getListeners()).hasSize(2).containsOnly(listener, listener2);
     }
 
     @Test
     void registerListener_processIdAndListenerExists_shouldReplace() {
         var listener = new TestListener();
-        manager.registerListener("test-process", listener);
-        manager.registerListener("test-process", listener);
+        manager.registerListener(listener);
+        manager.registerListener(listener);
 
-        assertThat(manager.getListeners()).containsKey("test-process");
-        assertThat(manager.getListeners().get("test-process")).hasSize(1).containsOnly(listener);
+        assertThat(manager.getListeners()).hasSize(1).containsOnly(listener);
     }
 
     @Test
     void unregisterListener() {
         var listener = new TestListener();
-        var pid = "test-pid";
-        manager.registerListener(pid, listener);
+        manager.registerListener(listener);
 
         manager.unregister(listener);
 
-        assertThat(manager.getListeners()).doesNotContainKey(pid);
+        assertThat(manager.getListeners()).doesNotContain(listener);
     }
 
 
     @Test
     void unregisterListener_listenerNotRegistered() {
         var listener = new TestListener();
-        var pid = "test-pid";
-        manager.registerListener(pid, listener);
+        manager.registerListener(listener);
 
         var listener2 = new TestListener();
         manager.unregister(listener2);
 
-        assertThat(manager.getListeners()).containsKey(pid);
-        assertThat(manager.getListeners().get(pid)).doesNotContain(listener2).containsOnly(listener);
+        assertThat(manager.getListeners()).doesNotContain(listener2).containsOnly(listener);
     }
 
     private static class TestListener implements TransferProcessListener {

--- a/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreExtension.java
+++ b/extensions/transfer/transfer-store-cosmos/src/main/java/com/microsoft/dagx/transfer/store/cosmos/CosmosTransferProcessStoreExtension.java
@@ -50,7 +50,7 @@ public class CosmosTransferProcessStoreExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
 
         monitor = context.getMonitor();
-        monitor.info("Initializing Cosmos Memory Transfer Process Store extension...");
+        monitor.info("Initializing Cosmos Transfer Process Store extension...");
 
         // configure cosmos db
         var cosmosAccountName = context.getSetting(COSMOS_ACCOUNTNAME_SETTING, null);

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,4 @@ awsVersion=2.16.60
 jodahFailsafeVersion=2.4.0
 storageBlobVersion=12.11.0
 cosmosSdkVersion=4.16.0
+eventGridSdkVersion=4.4.0

--- a/integration/integration-core/src/test/java/ClientRunner.java
+++ b/integration/integration-core/src/test/java/ClientRunner.java
@@ -69,9 +69,12 @@ public class ClientRunner {
             var usOrEuRequest = createRequestAws("us-eu-request-" + UUID.randomUUID(), DataEntry.Builder.newInstance().id(artifact).build());
 
             final TransferInitiateResponse response = processManager.initiateClientRequest(usOrEuRequest);
-            observable.registerListener(response.getId(), new TransferProcessListener() {
+            observable.registerListener(new TransferProcessListener() {
                 @Override
                 public void completed(TransferProcess process) {
+                    if (process.getId().equals(response.getId())) {
+                        return;
+                    }
                     //simulate data egress
                     try {
                         Thread.sleep(2000);
@@ -84,6 +87,9 @@ public class ClientRunner {
 
                 @Override
                 public void deprovisioned(TransferProcess process) {
+                    if (process.getId().equals(response.getId())) {
+                        return;
+                    }
                     latch.countDown();
                 }
             });
@@ -100,7 +106,7 @@ public class ClientRunner {
 
 
     @Test
-    @Disabled
+//    @Disabled
     void processClientRequest_toAzureStorage(RemoteMessageDispatcherRegistry dispatcherRegistry, TransferProcessManager processManager, TransferProcessObservable observable, TransferProcessStore store) throws Exception {
         var query = QueryRequest.Builder.newInstance()
                 .connectorAddress(PROVIDER_CONNECTOR)
@@ -122,9 +128,12 @@ public class ClientRunner {
             var usOrEuRequest = createRequestAzure("us-eu-request-" + UUID.randomUUID(), DataEntry.Builder.newInstance().id(artifact).build());
 
             final TransferInitiateResponse response = processManager.initiateClientRequest(usOrEuRequest);
-            observable.registerListener(response.getId(), new TransferProcessListener() {
+            observable.registerListener(new TransferProcessListener() {
                 @Override
                 public void completed(TransferProcess process) {
+                    if (process.getId().equals(response.getId())) {
+                        return;
+                    }
                     //simulate data egress
                     try {
                         Thread.sleep(2000);
@@ -137,6 +146,9 @@ public class ClientRunner {
 
                 @Override
                 public void deprovisioned(TransferProcess process) {
+                    if (process.getId().equals(response.getId())) {
+                        return;
+                    }
                     latch.countDown();
                 }
             });

--- a/scripts/aks-cluster/main.tf
+++ b/scripts/aks-cluster/main.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=2.62.1"
+      version = ">= 2.66.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = ">=1.5.0"
+      version = ">=1.6.0"
     }
   }
 }

--- a/scripts/atlas-deployment/main.tf
+++ b/scripts/atlas-deployment/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 2.62.1"
+      version = ">= 2.66.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/scripts/connector-deployment/main.tf
+++ b/scripts/connector-deployment/main.tf
@@ -100,6 +100,14 @@ resource "kubernetes_deployment" "connector-deployment" {
             name = "COSMOS_DB"
             value = var.container_environment.cosmosDb
           }
+          env{
+            name= "TOPIC_NAME"
+            value= var.events.topic_name
+          }
+          env{
+            name = "TOPIC_ENDPOINT"
+            value = var.events.topic_endpoint
+          }
           port {
             container_port = 8181
             host_port = 8181

--- a/scripts/connector-deployment/main.tf
+++ b/scripts/connector-deployment/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
-      version = ">= 2.62.1"
+      source  = "hashicorp/azurerm"
+      version = ">= 2.66.0"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"

--- a/scripts/connector-deployment/variables.tf
+++ b/scripts/connector-deployment/variables.tf
@@ -45,12 +45,12 @@ variable "container_environment" {
   })
 }
 
-variable "certificate_mount_config"{
+variable "certificate_mount_config" {
   type = object({
     accountName = string
-    accountKey  = string
+    accountKey = string
   })
-  
+
 }
 
 variable "public-ip" {
@@ -58,5 +58,12 @@ variable "public-ip" {
     ip_address = string
     fqdn = string
     domain_name_label = string
+  })
+}
+
+variable "events" {
+  type = object({
+    topic_name = string
+    topic_endpoint = string
   })
 }

--- a/scripts/cosmos.tf
+++ b/scripts/cosmos.tf
@@ -1,14 +1,14 @@
 resource "azurerm_cosmosdb_account" "dagx-cosmos" {
-  location            = azurerm_resource_group.rg.location
+  location            = azurerm_resource_group.core-resourcegroup.location
   name                = "dagx-cosmos"
-  resource_group_name = azurerm_resource_group.rg.name
+  resource_group_name = azurerm_resource_group.core-resourcegroup.name
   offer_type          = "Standard"
   consistency_policy {
     consistency_level = "Session"
   }
   geo_location {
     failover_priority = 0
-    location          = azurerm_resource_group.rg.location
+    location          = azurerm_resource_group.core-resourcegroup.location
   }
 
 }
@@ -16,7 +16,7 @@ resource "azurerm_cosmosdb_account" "dagx-cosmos" {
 resource "azurerm_cosmosdb_sql_database" "dagx-database" {
   account_name        = azurerm_cosmosdb_account.dagx-cosmos.name
   name                = "dagx-database"
-  resource_group_name = azurerm_resource_group.rg.name
+  resource_group_name = azurerm_resource_group.core-resourcegroup.name
   throughput          = 400
 }
 

--- a/scripts/eventgrid.tf
+++ b/scripts/eventgrid.tf
@@ -1,0 +1,45 @@
+resource "azurerm_eventgrid_topic" "dagx-topic" {
+  location            = azurerm_resource_group.core-resourcegroup.location
+  name                = "connector-events"
+  resource_group_name = azurerm_resource_group.core-resourcegroup.name
+}
+
+resource "azurerm_key_vault_secret" "event-grid-key" {
+  key_vault_id = azurerm_key_vault.dagx-terraform-vault.id
+  name         = azurerm_eventgrid_topic.dagx-topic.name
+  value        = azurerm_eventgrid_topic.dagx-topic.primary_access_key
+}
+
+data "http" "template" {
+  url = "https://raw.githubusercontent.com/Azure-Samples/azure-event-grid-viewer/master/azuredeploy.json"
+}
+
+resource "azurerm_template_deployment" "eventviewer" {
+  deployment_mode     = "Incremental"
+  name                = "event-viewer-app"
+  resource_group_name = azurerm_resource_group.core-resourcegroup.name
+  template_body       = data.http.template.body
+  parameters = {
+    siteName        = var.eventViewerUrl
+    hostingPlanName = "viewerhost"
+  }
+}
+variable "eventViewerUrl" {
+  default = "dagx-eventviewer"
+}
+
+resource "azurerm_eventgrid_event_subscription" "eventviewer" {
+  name  = "event-viewer-subscription"
+  scope = azurerm_eventgrid_topic.dagx-topic.id
+  webhook_endpoint {
+    url = "https://${var.eventViewerUrl}.azurewebsites.net/api/updates"
+  }
+}
+
+output "topic-endpoint" {
+  value = azurerm_eventgrid_topic.dagx-topic.endpoint
+}
+
+output "viewer-url" {
+  value = "https://${var.eventViewerUrl}.azurewebsites.net/"
+}

--- a/scripts/main.tf
+++ b/scripts/main.tf
@@ -354,5 +354,9 @@ module "connector-deployment" {
     accountName = var.backend_account_name
     accountKey  = var.backend_account_key
   }
+  events = {
+    topic_name     = azurerm_eventgrid_topic.dagx-topic.name
+    topic_endpoint = azurerm_eventgrid_topic.dagx-topic.endpoint
+  }
 }
 

--- a/scripts/main.tf
+++ b/scripts/main.tf
@@ -9,11 +9,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 2.65.0"
+      version = ">= 2.66.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = ">=1.5.0"
+      version = ">=1.6.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
@@ -32,6 +32,10 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = "3.45.0"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = ">=2.1.0"
     }
   }
 }
@@ -128,7 +132,7 @@ data "azurerm_kubernetes_cluster" "connector" {
 
 data "azurerm_client_config" "current" {}
 
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "core-resourcegroup" {
   name     = "${var.resourcesuffix}-resources"
   location = var.location
 }
@@ -157,8 +161,8 @@ resource "azuread_service_principal" "dagx-terraform-app-sp" {
 # Keyvault
 resource "azurerm_key_vault" "dagx-terraform-vault" {
   name                        = "dagx-${var.resourcesuffix}-vault"
-  location                    = azurerm_resource_group.rg.location
-  resource_group_name         = azurerm_resource_group.rg.name
+  location                    = azurerm_resource_group.core-resourcegroup.location
+  resource_group_name         = azurerm_resource_group.core-resourcegroup.name
   enabled_for_disk_encryption = false
   tenant_id                   = data.azurerm_client_config.current.tenant_id
   soft_delete_retention_days  = 7
@@ -186,8 +190,8 @@ resource "azurerm_role_assignment" "current-user" {
 #storage account
 resource "azurerm_storage_account" "dagxblobstore" {
   name                     = "dagxtfblob"
-  resource_group_name      = azurerm_resource_group.rg.name
-  location                 = azurerm_resource_group.rg.location
+  resource_group_name      = azurerm_resource_group.core-resourcegroup.name
+  location                 = azurerm_resource_group.core-resourcegroup.location
   account_tier             = "Standard"
   account_replication_type = "GRS"
   account_kind             = "BlobStorage"
@@ -251,10 +255,10 @@ resource "azurerm_key_vault_secret" "nifi-credentials" {
 }
 
 resource "azurerm_container_group" "dagx-nifi" {
-  location            = azurerm_resource_group.rg.location
+  location            = azurerm_resource_group.core-resourcegroup.location
   name                = "dagx-nifi-continst"
   os_type             = "Linux"
-  resource_group_name = azurerm_resource_group.rg.name
+  resource_group_name = azurerm_resource_group.core-resourcegroup.name
   dns_name_label      = "${var.resourcesuffix}-dagx-nifi"
   container {
     cpu    = 4

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -54,6 +54,8 @@ include(":extensions:dataseed:dataseed-nifi")
 include(":extensions:dataseed:dataseed-azure")
 include(":extensions:dataseed:dataseed-aws")
 
+include(":extensions:events:events-azure")
+
 include(":policy:policy-model")
 include(":policy:policy-engine")
 

--- a/spi/src/main/java/com/microsoft/dagx/spi/Observable.java
+++ b/spi/src/main/java/com/microsoft/dagx/spi/Observable.java
@@ -6,6 +6,30 @@
 
 package com.microsoft.dagx.spi;
 
-public interface Observable<T> {
-    void unregister(T listener);
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+public abstract class Observable<T> {
+
+    private final Collection<T> listeners;
+
+    protected Observable() {
+        listeners = new ConcurrentLinkedQueue<>();
+    }
+
+    public Collection<T> getListeners() {
+        return listeners;
+    }
+
+    public void registerListener(T listener) {
+
+        if (!listeners.contains(listener)) {
+            listeners.add(listener);
+        }
+    }
+
+    public void unregister(T listener) {
+        listeners.remove(listener);
+    }
 }

--- a/spi/src/main/java/com/microsoft/dagx/spi/metadata/MetadataListener.java
+++ b/spi/src/main/java/com/microsoft/dagx/spi/metadata/MetadataListener.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *  All rights reserved.
+ *
+ */
+
+package com.microsoft.dagx.spi.metadata;
+
+public interface MetadataListener {
+    void querySubmitted();
+
+    void searchInitiated();
+
+    void metadataItemAdded();
+
+    void metadataItemUpdated();
+}

--- a/spi/src/main/java/com/microsoft/dagx/spi/metadata/MetadataObservable.java
+++ b/spi/src/main/java/com/microsoft/dagx/spi/metadata/MetadataObservable.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ *  All rights reserved.
+ *
+ */
+
+package com.microsoft.dagx.spi.metadata;
+
+import com.microsoft.dagx.spi.Observable;
+
+public class MetadataObservable extends Observable<MetadataListener> {
+}

--- a/spi/src/main/java/com/microsoft/dagx/spi/system/ServiceExtensionContext.java
+++ b/spi/src/main/java/com/microsoft/dagx/spi/system/ServiceExtensionContext.java
@@ -43,6 +43,15 @@ public interface ServiceExtensionContext {
     <T> T getService(Class<T> type);
 
     /**
+     * Returns a system service, but does not throw an exception if not found.
+     *
+     * @return null if not found
+     */
+    default <T> T getService(Class<T> type, boolean isOptional) {
+        return getService(type);
+    }
+
+    /**
      * Registers a service
      */
     default <T> void registerService(Class<T> type, T service) {

--- a/spi/src/main/java/com/microsoft/dagx/spi/transfer/TransferProcessListener.java
+++ b/spi/src/main/java/com/microsoft/dagx/spi/transfer/TransferProcessListener.java
@@ -9,9 +9,33 @@ package com.microsoft.dagx.spi.transfer;
 import com.microsoft.dagx.spi.types.domain.transfer.TransferProcess;
 
 public interface TransferProcessListener {
+    default void created(TransferProcess process) {
+    }
+
+    default void provisioning(TransferProcess process) {
+    }
+
+    default void provisioned(TransferProcess process) {
+    }
+
+    default void inProgress(TransferProcess process) {
+    }
+
     default void completed(TransferProcess process) {
     }
 
+    default void deprovisioning(TransferProcess process) {
+    }
+
     default void deprovisioned(TransferProcess process) {
+    }
+
+    default void ended(TransferProcess process) {
+    }
+
+    default void error(TransferProcess process) {
+    }
+
+    default void requested(TransferProcess process) {
     }
 }

--- a/spi/src/main/java/com/microsoft/dagx/spi/transfer/TransferProcessObservable.java
+++ b/spi/src/main/java/com/microsoft/dagx/spi/transfer/TransferProcessObservable.java
@@ -8,6 +8,5 @@ package com.microsoft.dagx.spi.transfer;
 
 import com.microsoft.dagx.spi.Observable;
 
-public interface TransferProcessObservable extends Observable<TransferProcessListener> {
-    void registerListener(String processId, TransferProcessListener listener);
+public abstract class TransferProcessObservable extends Observable<TransferProcessListener> {
 }


### PR DESCRIPTION
Various components in the connector can emit events (i.e. they are `Observable`), such as "Transfer Process created" or "metadata query submitted". Emitting events is done by invoking the appropriate methods on their listeners, who can then process the information.
Additionally, a listener has been implemented that forwards those events to an Azure Event Grid topic, which is a lightweight eventing pipeline.

Also, a rudimentary event viewer has been deployed which can be found at https://dagx-eventviewer.azurewebsites.net/. Once the deployed connector emits any events, they will be displayed there.
